### PR TITLE
Ed/parser error

### DIFF
--- a/app/views/harvest_jobs/_form.html.erb
+++ b/app/views/harvest_jobs/_form.html.erb
@@ -14,30 +14,27 @@ http://digitalnz.org/supplejack
 </h3>
 
 <% if @parser.valid_parser?(@harvest_job.environment, @version) %>
-  <%= simple_form_for @harvest_job, remote: true do |f| %>
-    <%= f.input :parser_id, as: :hidden %>
-    <%= f.input :version_id, as: :hidden %>
-    <%= f.input :user_id, as: :hidden %>
-    <%= f.input :environment, as: :hidden %>
-
-    <%= f.input :mode, collection: @parser.modes, as: :radio_buttons, checked: @parser.modes.first, label_html: {class: "large"} %>
-    <% unless @parser.modes.flatten.include?('full_and_flush') %>
-      <input type="radio" disabled="true" title="Full And Flush is currently disabled.">Full And Flush
-    <% end %>
-    <span class="parser-harvest-mode"><%= "(#{t("parsers.disable_full_and_flush")})" unless @parser.allow_full_and_flush %></span>
-    <br/></br>
-    <%= f.input :limit, label: t("parsers.records_to_harvest"), label_html: {class: "large"} %>
-
-    <% if @parser.enrichment_definitions(@harvest_job.environment, @version).any? %>
-      <%= f.input :enrichments, collection: @parser.enrichment_definitions(@harvest_job.environment, @version).keys.map {|k| [k.to_s.titleize, k]}, as: :check_boxes, label: t("parsers.enrichments_to_run"), label_html: {class: "large"} %>
-    <% end %>
-
-    <br/>
-
-    <%= f.button :submit, "Start Harvest", class: "button columns twelve" %>
-  <% end %>
-
-<% else %>
   <%= render "parsers/error", error: @parser.error %>
 <% end %>
+<%= simple_form_for @harvest_job, remote: true do |f| %>
+  <%= f.input :parser_id, as: :hidden %>
+  <%= f.input :version_id, as: :hidden %>
+  <%= f.input :user_id, as: :hidden %>
+  <%= f.input :environment, as: :hidden %>
 
+  <%= f.input :mode, collection: @parser.modes, as: :radio_buttons, checked: @parser.modes.first, label_html: {class: "large"} %>
+  <% unless @parser.modes.flatten.include?('full_and_flush') %>
+    <input type="radio" disabled="true" title="Full And Flush is currently disabled.">Full And Flush
+  <% end %>
+  <span class="parser-harvest-mode"><%= "(#{t("parsers.disable_full_and_flush")})" unless @parser.allow_full_and_flush %></span>
+  <br/></br>
+  <%= f.input :limit, label: t("parsers.records_to_harvest"), label_html: {class: "large"} %>
+
+  <% if @parser.enrichment_definitions(@harvest_job.environment, @version).any? %>
+    <%= f.input :enrichments, collection: @parser.enrichment_definitions(@harvest_job.environment, @version).keys.map {|k| [k.to_s.titleize, k]}, as: :check_boxes, label: t("parsers.enrichments_to_run"), label_html: {class: "large"} %>
+  <% end %>
+
+  <br/>
+
+  <%= f.button :submit, "Start Harvest", class: "button columns twelve" %>
+<% end %>

--- a/app/views/harvest_jobs/_form.html.erb
+++ b/app/views/harvest_jobs/_form.html.erb
@@ -13,7 +13,7 @@ http://digitalnz.org/supplejack
   <span class='parser-tag  round label'><%= "#{@version.message}"%></span>
 </h3>
 
-<% if @parser.valid_parser?(@harvest_job.environment, @version) %>
+<% unless @parser.valid_parser?(@harvest_job.environment, @version) %>
   <%= render "parsers/error", error: @parser.error %>
 <% end %>
 <%= simple_form_for @harvest_job, remote: true do |f| %>


### PR DESCRIPTION
Displaying the harvest form and error together. As SJ skips over ruby blocks of the expected variables are set in the parser on harvesting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalnz/supplejack_manager/8)
<!-- Reviewable:end -->
