### PR TITLE
Fix Harvester Schedule Form Issue

### DIFF
--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -131,7 +131,12 @@ class Parser
   # @param version [Version]
   # @return [Object] the SupplejackCommon::Loader object
   def enrichment_definitions(environment, version = nil)
-    self.content = version.content if version
+
+    if version.nil?
+      self.content = self.current_version(environment).content
+    else
+      self.content = version.content
+    end
 
     begin
       loader = SupplejackCommon::Loader.new(self, environment)

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -135,9 +135,7 @@ class Parser
       self.content = version.content
     else
       env_versions = self.versions.where(tags: environment)
-      if env_versions.any?
-        self.content = env_versions.last
-      end
+      self.content = env_versions.last.content if env_versions.any?
     end
 
     begin

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -131,14 +131,15 @@ class Parser
   # @param version [Version]
   # @return [Object] the SupplejackCommon::Loader object
   def enrichment_definitions(environment, version = nil)
-
-    if version.nil? && !self.versions.empty?
-      self.content = self.current_version(environment).content
-    elsif version
+    if version
       self.content = version.content
+    else
+      env_versions = self.versions.where(tags: environment)
+      if env_versions.any?
+        self.content = env_versions.last
+      end
     end
 
-    # binding.pry
     begin
       loader = SupplejackCommon::Loader.new(self, environment)
 

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -132,12 +132,13 @@ class Parser
   # @return [Object] the SupplejackCommon::Loader object
   def enrichment_definitions(environment, version = nil)
 
-    if version.nil?
+    if version.nil? && !self.versions.empty?
       self.content = self.current_version(environment).content
-    else
+    elsif version
       self.content = version.content
     end
 
+    # binding.pry
     begin
       loader = SupplejackCommon::Loader.new(self, environment)
 

--- a/spec/factories/version.rb
+++ b/spec/factories/version.rb
@@ -12,5 +12,19 @@ FactoryGirl.define do
     tags      nil
     user_id   "577d8c270403714b67000001"
     content   "default: \"Research papers for 1\"\r\n\t  attributes :display_collection, :primary_collection,   default: \"Massey Research Online"
+
+    trait :santos do
+      tags ['santos clause']
+    end
+
+    trait :production do
+      tags ['production']
+      content "version for production"
+    end
+
+    trait :staging do
+      tags ['staging']
+      content  "version for staging"
+    end
   end
 end

--- a/spec/models/parser_spec.rb
+++ b/spec/models/parser_spec.rb
@@ -155,6 +155,17 @@ describe Parser do
       end
     end
 
+    context 'when version is not passed but the parser has a tagged version' do
+      before(:each) do
+        parser.versions << FactoryGirl.build(:version, :staging)
+      end
+
+      it "parser is set as the content of the last tagged version" do
+        parser.enrichment_definitions("staging")
+        expect(parser.content).to eq "version for staging"
+      end
+    end
+
     context 'when version is passed' do
       it "content is updated" do
         parser.should_receive(:content)


### PR DESCRIPTION
Acceptance Criteria
=================
Currently, Harvester Schedule Form is loading latest version of Parser across all environments. I.e, if there is no enrichment code in the top (untagged) parser version, while the latest version that has been tagged as Staging has got enrichment. The (Staging) schedule form should pick up the latest staging version which should have enrichments (option).

Harvester Scheduler form pick up the correct version of Parser when loading the "New Schedule" Form.

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] All Tests are Passing
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Linters Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalnz/supplejack_manager/12)
<!-- Reviewable:end -->
