### PR TITLE
ADD YEAR TO SUPPLEJACK VERSION DISPLAY INFO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.3.1
 services:
   - mongodb
 before_script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
   specs:
     actionmailer (3.2.22.2)
       actionpack (= 3.2.22.2)
-      mail (~> 2.4.4)
+      mail (~> 2.5.4)
     actionpack (3.2.22.2)
       activemodel (= 3.2.22.2)
       activesupport (= 3.2.22.2)
@@ -80,7 +80,7 @@ GEM
     activeresource-response (0.5.3)
       activeresource (>= 3.0)
     activesupport (3.2.22.2)
-      i18n (~> 0.6)
+      i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.2)
     airbrake (5.3.0)
@@ -187,7 +187,7 @@ GEM
       activesupport
       json
     htmlentities (4.3.4)
-    i18n (0.7.0)
+    i18n (0.8.4)
     journey (1.0.4)
     jquery-rails (2.1.4)
       railties (>= 3.0, < 5.0)
@@ -214,8 +214,7 @@ GEM
       activesupport (>= 3)
       railties (>= 3)
     lumberjack (1.0.10)
-    mail (2.4.4)
-      i18n (>= 0.4.0)
+    mail (2.5.5)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     method_source (0.8.1)
@@ -244,7 +243,7 @@ GEM
     orm_adapter (0.5.0)
     parser (2.3.1.2)
       ast (~> 2.2)
-    polyglot (0.3.3)
+    polyglot (0.3.5)
     power_assert (0.2.6)
     powerpack (0.1.1)
     pry (0.9.11.4)
@@ -256,7 +255,7 @@ GEM
     quiet_assets (1.0.1)
       railties (~> 3.1)
     rack (1.4.7)
-    rack-cache (1.6.1)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-ssl (1.3.4)
       rack
@@ -278,7 +277,7 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     rainbow (2.1.0)
-    raindrops (0.17.0)
+    raindrops (0.18.0)
     rake (11.2.2)
     rb-fsevent (0.9.2)
     rdoc (3.12.2)
@@ -348,7 +347,7 @@ GEM
     timecop (0.5.2)
     traceroute (0.5.0)
       rails (>= 3.0.0)
-    treetop (1.4.12)
+    treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.41)
@@ -356,10 +355,9 @@ GEM
       execjs (>= 0.3.0)
       multi_json (~> 1.0, >= 1.0.2)
     unicode-display_width (1.1.0)
-    unicorn (4.6.2)
+    unicorn (5.3.0)
       kgio (~> 2.6)
-      rack
-      raindrops (~> 0.17.0)
+      raindrops (~> 0.7)
     unicorn-rails (1.0.1)
       rack
       unicorn

--- a/app/helpers/parsers_helper.rb
+++ b/app/helpers/parsers_helper.rb
@@ -78,7 +78,7 @@ module ParsersHelper
     end
   end
 
-  def environment_tag(environment, nested_tag=nil)
+  def environment_tag(environment, nested_tag = nil)
     content_tag(:span, safe_join([content_tag(:span, '', class: 'arrow arrow-left'), t("parsers.environments.#{environment}"), nested_tag]), class: "version-tag #{environment}")
   end
 
@@ -91,6 +91,7 @@ module ParsersHelper
   end
 
   def localize_date_time(date_time)
-    ActiveSupport::TimeZone['Wellington'].parse(date_time.to_s)
+    local_date = ActiveSupport::TimeZone['Wellington'].parse(date_time.to_s)
+    local_date.strftime('%d %b %Y %H:%M')
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -49,5 +49,4 @@ class Ability
       cannot :read, :collection_record
     end
   end
-
 end

--- a/app/views/versions/_version_list.html.erb
+++ b/app/views/versions/_version_list.html.erb
@@ -44,7 +44,7 @@ http://digitalnz.org/supplejack
   <% versionable.versions.desc(:created_at).each_with_index do |version, index| %>
     <div class="version <%= 'active' if @version.try(:id) == version.id %> <%= 'hidden' if index > 15 %>">
       <%= link_to version.message || "No message",  send(:"#{versionable_path}_path", versionable, version) %>
-      <p><%= l(localize_date_time(version.created_at), format: :short) %> by <%= version.user.try(:first_name) %></p>
+      <p><%= localize_date_time(version.created_at) %> by <%= version.user.try(:first_name) %></p>
 
       <%= environment_tags(version, versionable) %>
     </div>

--- a/spec/helpers/parsers_helper_spec.rb
+++ b/spec/helpers/parsers_helper_spec.rb
@@ -48,6 +48,12 @@ describe ParsersHelper do
       end
     end
 
+    context '#localize_date_time' do
+      it 'return date in dd M yyyy hh:mm format' do
+        expect(localize_date_time(Time.zone.now)).to match(/^[0-9]{2} [a-zA-Z]{3} [0-9]{4} [0-9]{2}:[0-9]{2}/)
+      end
+    end
+
     context "older tags" do
       let(:current_version) { mock(:version, id: "444", tags: ["production"]) }
 
@@ -77,5 +83,4 @@ describe ParsersHelper do
       end
     end
   end
-  
 end


### PR DESCRIPTION
Why  : Parser version require to display date with Year. Currently we are using internationalization which is limited
What : Added date formating from the helper and removed internationalization