### PR TITLE
DISPLAY ERROR INFO FOR FAILED JOBS

### DIFF
--- a/app/assets/stylesheets/harvest_jobs.scss
+++ b/app/assets/stylesheets/harvest_jobs.scss
@@ -13,7 +13,7 @@
   }
 }
 
-#accordion {
+.accordion {
   h3.error {
     margin: 0;
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,6 +38,14 @@ module ApplicationHelper
     end
   end
 
+  def format_backtrace(backtrace)
+    content_tag 'div' do
+      backtrace.each_with_index do |span_content, index|
+        concat content_tag("small", span_content)
+      end
+    end
+  end
+
   def safe_users_path(params={})
     current_user.admin? ? users_path(params) : root_path
   end

--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -103,14 +103,27 @@ http://digitalnz.org/supplejack
   
    <% if @harvest_job.harvest_failure.present? %>
     <h5><%= t('harvest_jobs.harvest_failure')%> </h5>
-    <span><%= @harvest_job.harvest_failure.message %></span>
+
+     <div id="harvest-job-errors-backtrace">
+      <div id="accordion-backtrace" class="accordion">
+        <h3 class="error">
+          <span><%= @harvest_job.harvest_failure.message %></span>
+        </h3>
+        <div>
+          <small>
+            <%= format_backtrace(@harvest_job.harvest_failure.backtrace) %>
+          </small>
+        </div>
+      </div>
+    </div>
   <% end %>
 
   <h5><%= t("harvest_jobs.invalid_records") %> <span class="errors-count">(<%= @harvest_job.invalid_records_count.to_i %>)</span></h5>
 
+
   <% if @harvest_job.invalid_records.any? %>
   <div id="harvest-job-invalid-errors">
-    <div id="accordion">
+    <div id="accordion-invalid" class="accordion">
       <% @harvest_job.invalid_records.each do |record| %>
         <h3 class="error">
           <span><%= record.error_messages.join(", ") %></span><span class="right"><%= record.created_at.try(:to_datetime) %></span>
@@ -129,7 +142,7 @@ http://digitalnz.org/supplejack
 
   <% if @harvest_job.failed_records.any? %>
   <div id="harvest-job-failed-errors">
-    <div id="accordion">
+    <div id="accordion-failed" class="accordion">
       <% @harvest_job.failed_records.each do |record| %>
         <h3 class="error">
           <span><%= record.message %></span><span class="right"><%= record.created_at.try(:to_datetime) %></span>

--- a/app/views/harvest_jobs/show.js.erb
+++ b/app/views/harvest_jobs/show.js.erb
@@ -9,7 +9,7 @@ http://digitalnz.org/supplejack
 %>
 
 $("#harvest-result").html('<%= j render @harvest_job %>').show();
-$("#accordion").accordion({heightStyle: "content",collapsible: true, active: false})
+$("#accordion-failed, #accordion-invalid, #accordion-backtrace").accordion({heightStyle: "content",collapsible: true, active: false})
 
 if ($("#harvest-end-time").length == 0) {
   HarvestJobsPoller.poll()

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,84 +10,90 @@ require "spec_helper"
 
 describe ApplicationHelper do
 
-	describe "#pretty_format" do
+  describe "#pretty_format" do
 
-		let(:raw_data) { {bill: "bob"}.to_json  }
-		let(:parser) { mock(:parser) }
+    let(:raw_data) { {bill: "bob"}.to_json  }
+    let(:parser) { mock(:parser) }
 
-		context "parser found" do
+    context "parser found" do
 
-			it "should find the parser & get the format" do
-				Parser.should_receive(:find).with("abc123") { parser }
-				parser.should_receive(:xml?)
-			  helper.pretty_format("abc123", raw_data)
-			end
+      it "should find the parser & get the format" do
+        Parser.should_receive(:find).with("abc123") { parser }
+        parser.should_receive(:xml?)
+        helper.pretty_format("abc123", raw_data)
+      end
 
-			before do 
-				Parser.stub(:find) { parser }
-			end
+      before do 
+        Parser.stub(:find) { parser }
+      end
 
-			context "json" do
-				before { parser.stub(:xml?) { false } }
+      context "json" do
+        before { parser.stub(:xml?) { false } }
 
-				it "should use coderay to format the raw_data" do
-				  CodeRay.should_receive(:scan).with("{\n  \"bill\": \"bob\"\n}", :json) { mock(:output).as_null_object }
-				  helper.pretty_format("abc123", raw_data)
-				end
+        it "should use coderay to format the raw_data" do
+          CodeRay.should_receive(:scan).with("{\n  \"bill\": \"bob\"\n}", :json) { mock(:output).as_null_object }
+          helper.pretty_format("abc123", raw_data)
+        end
 
-				it "should pretty generate the JSON if it is json" do
-					JSON.should_receive(:pretty_generate).with({"bill"=>"bob"})
-				  helper.pretty_format("abc123", raw_data)
-				end
-			end
+        it "should pretty generate the JSON if it is json" do
+          JSON.should_receive(:pretty_generate).with({"bill"=>"bob"})
+          helper.pretty_format("abc123", raw_data)
+        end
+      end
 
-			context "xml" do
-				before { parser.stub(:xml?) { true } }
+      context "xml" do
+        before { parser.stub(:xml?) { true } }
 
-				it "should not pretty generate the XML" do
-				  JSON.should_not_receive(:pretty_generate).with(raw_data)
-				  helper.pretty_format("abc123", raw_data)
-				end
-			end
-		end
+        it "should not pretty generate the XML" do
+          JSON.should_not_receive(:pretty_generate).with(raw_data)
+          helper.pretty_format("abc123", raw_data)
+        end
+      end
+    end
 
-		context "parser not found" do
-			it "should return the raw data if the parser is not found" do
-			  helper.pretty_format("abc123", raw_data).should eq raw_data
-			end
-		end
+    context "parser not found" do
+      it "should return the raw data if the parser is not found" do
+        helper.pretty_format("abc123", raw_data).should eq raw_data
+      end
+    end
 
-	end
+  end
 
-	describe "safe_users_path" do
-		context "admin user" do
-			it "should be able to access users_path" do
-		  	helper.stub(:current_user) { double(:user, admin?: true) }
-		  	helper.safe_users_path.should eq users_path
-			end
-		end
+  describe '#format_backtrace' do
+    it 'returns a div sith small lines' do
+      expect(helper.format_backtrace(['foo', 'bar'])).to eq '<div><small>foo</small><small>bar</small></div>'
+    end
+  end
 
-		context "standard user" do
-			it "should not be able to access users_path" do
-		  	helper.stub(:current_user) { double(:user, admin?: false) }
-		  	helper.safe_users_path.should eq root_path
-			end
-		end
-	end
+  describe "safe_users_path" do
+    context "admin user" do
+      it "should be able to access users_path" do
+        helper.stub(:current_user) { double(:user, admin?: true) }
+        helper.safe_users_path.should eq users_path
+      end
+    end
 
-	describe "can_show_button" do
-		context "authorised" do
-			it "should return empty string" do
-			 helper.stub(:can?) { true }
-			 helper.can_show_button(:create, Source).should eq ''
-			end
-		end
-		
-		context "unauthorised" do
-			it "should return disabled" do
-			 helper.stub(:can?) { false }
-			 helper.can_show_button(:create, Source).should eq 'disabled'
-			end
-		end
-	end
+    context "standard user" do
+      it "should not be able to access users_path" do
+        helper.stub(:current_user) { double(:user, admin?: false) }
+        helper.safe_users_path.should eq root_path
+      end
+    end
+  end
+
+  describe "can_show_button" do
+    context "authorised" do
+      it "should return empty string" do
+       helper.stub(:can?) { true }
+       helper.can_show_button(:create, Source).should eq ''
+      end
+    end
+    
+    context "unauthorised" do
+      it "should return disabled" do
+       helper.stub(:can?) { false }
+       helper.can_show_button(:create, Source).should eq 'disabled'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Why  : Error backtrace needs to be displayed in failed job.
What : Added accordion, helper, css and spec for this.