### PR TITLE
CLEAN UP DISPLAY OF ERRORS ON HARVEST JOB PAGE: As a Harvester I want to see information about harvest errors, so that I can easily follow up where necessary

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,9 +1,9 @@
 // The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-// and is licensed under the GNU General Public License, version 3. Some components are 
-// third party components that are licensed under the MIT license or otherwise publicly available. 
-// See https://github.com/DigitalNZ/supplejack_manager for details. 
-// 
-// Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+// and is licensed under the GNU General Public License, version 3. Some components are
+// third party components that are licensed under the MIT license or otherwise publicly available.
+// See https://github.com/DigitalNZ/supplejack_manager for details.
+//
+// Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 // http://digitalnz.org/supplejack
 
 
@@ -52,3 +52,4 @@
 //= require partners
 //= require sources
 //= require suppressed_collections
+//= require harvest_errors

--- a/app/assets/javascripts/code_mirror_setup.js.coffee
+++ b/app/assets/javascripts/code_mirror_setup.js.coffee
@@ -1,9 +1,9 @@
 # The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. Some components are 
-# third party components that are licensed under the MIT license or otherwise publicly available. 
-# See https://github.com/DigitalNZ/supplejack_manager for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+# and is licensed under the GNU General Public License, version 3. Some components are
+# third party components that are licensed under the MIT license or otherwise publicly available.
+# See https://github.com/DigitalNZ/supplejack_manager for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 # http://digitalnz.org/supplejack
 
 $ ->
@@ -11,7 +11,6 @@ $ ->
 
   Harvester.readOnly = ->
     $(Harvester.textArea).hasClass("read-only")
-
 
   if Harvester.textArea != undefined
     Harvester.myCodeMirror = CodeMirror.fromTextArea Harvester.textArea, {

--- a/app/assets/javascripts/harvest_errors.js
+++ b/app/assets/javascripts/harvest_errors.js
@@ -1,0 +1,17 @@
+$(function() {
+
+  var code_mirror_text_areas = document.getElementsByClassName('code-editor-multiple');
+
+  $(code_mirror_text_areas).each(function(key, value) {
+    CodeMirror.fromTextArea(value, {
+      lineNumbers: true,
+      theme: 'monokai',
+      tabSize: 2,
+      readOnly: true,
+      lineSeperator: ',',
+    })
+  });
+
+  $("#accordion-failed, #accordion-invalid, #accordion-backtrace").accordion({heightStyle: "content",collapsible: true, active: false})
+
+});

--- a/app/assets/javascripts/harvest_errors.js
+++ b/app/assets/javascripts/harvest_errors.js
@@ -12,6 +12,6 @@ $(function() {
     })
   });
 
-  $("#accordion-failed, #accordion-invalid, #accordion-backtrace").accordion({heightStyle: "content",collapsible: true, active: false})
+  $("#accordion-failed, #accordion-invalid, #accordion-backtrace").accordion({heightStyle: "content",collapsible: true, active: false});
 
 });

--- a/app/assets/stylesheets/harvest_jobs.scss
+++ b/app/assets/stylesheets/harvest_jobs.scss
@@ -1,9 +1,9 @@
 // The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-// and is licensed under the GNU General Public License, version 3. Some components are 
-// third party components that are licensed under the MIT license or otherwise publicly available. 
-// See https://github.com/DigitalNZ/supplejack_manager for details. 
-// 
-// Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+// and is licensed under the GNU General Public License, version 3. Some components are
+// third party components that are licensed under the MIT license or otherwise publicly available.
+// See https://github.com/DigitalNZ/supplejack_manager for details.
+//
+// Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 // http://digitalnz.org/supplejack
 
 #harvest-result {
@@ -18,7 +18,7 @@
     margin: 0;
   }
   span.ui-accordion-header-icon {
-    float: right; 
+    float: right;
   }
   table.CodeRay {
     margin: 0;
@@ -49,12 +49,17 @@
   }
 }
 
+.errors-count {
+  color: $alertColor;
+}
+
 #harvest-result .error {
   background: lighten($alertColor, 52%);
   border: 1px solid $alertColor;
   color: $alertColor;
   margin-bottom: 5px;
   padding: 6px;
+  font-size: 1.8rem;
 }
 
 #harvest-stats {
@@ -80,5 +85,3 @@
     }
   }
 }
-
-

--- a/app/models/harvest_job.rb
+++ b/app/models/harvest_job.rb
@@ -1,9 +1,9 @@
 # The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. Some components are 
-# third party components that are licensed under the MIT license or otherwise publicly available. 
-# See https://github.com/DigitalNZ/supplejack_manager for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+# and is licensed under the GNU General Public License, version 3. Some components are
+# third party components that are licensed under the MIT license or otherwise publicly available.
+# See https://github.com/DigitalNZ/supplejack_manager for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 # http://digitalnz.org/supplejack
 
 class HarvestJob < AbstractJob
@@ -27,6 +27,7 @@ class HarvestJob < AbstractJob
     attribute :mode,                  :string
     attribute :posted_records_count,  :integer
     attribute :limit,                 :integer
+    attribute :retried_records_count, :integer
   end
 
   include ActiveResource::SchemaTypes

--- a/app/views/abstract_jobs/index.html.erb
+++ b/app/views/abstract_jobs/index.html.erb
@@ -67,7 +67,7 @@ http://digitalnz.org/supplejack
 
       <td><%= abstract_job.records_count %></td>
 
-      <% if abstract_job.invalid_records_count > 0 || abstract_job.failed_records_count > 0 %>
+      <% if ((abstract_job.invalid_records_count.present? && abstract_job.invalid_records_count > 0) || (abstract_job.failed_records_count.present? && abstract_job.failed_records_count > 0)) %>
         <td><span class='errors-count'><strong><%= abstract_job.invalid_records_count %>/<%= abstract_job.failed_records_count %></strong></span></td>
       <% else %>
         <td><%= abstract_job.invalid_records_count %>/<%= abstract_job.failed_records_count %></td>

--- a/app/views/abstract_jobs/index.html.erb
+++ b/app/views/abstract_jobs/index.html.erb
@@ -1,10 +1,10 @@
-<%#  
+<%#
 The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-and is licensed under the GNU General Public License, version 3. Some components are 
-third party components that are licensed under the MIT license or otherwise publicly available. 
-See https://github.com/DigitalNZ/supplejack_manager for details. 
+and is licensed under the GNU General Public License, version 3. Some components are
+third party components that are licensed under the MIT license or otherwise publicly available.
+See https://github.com/DigitalNZ/supplejack_manager for details.
 
-Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 http://digitalnz.org/supplejack
 %>
 
@@ -66,7 +66,12 @@ http://digitalnz.org/supplejack
       <% end %>
 
       <td><%= abstract_job.records_count %></td>
-      <td><%= abstract_job.invalid_records_count %>/<%= abstract_job.failed_records_count %></td>
+
+      <% if abstract_job.invalid_records_count > 0 || abstract_job.failed_records_count > 0 %>
+        <td><span class='errors-count'><strong><%= abstract_job.invalid_records_count %>/<%= abstract_job.failed_records_count %></strong></span></td>
+      <% else %>
+        <td><%= abstract_job.invalid_records_count %>/<%= abstract_job.failed_records_count %></td>
+      <% end %>
 
       <td>
         <% if abstract_job._type == "HarvestJob" %>
@@ -75,7 +80,7 @@ http://digitalnz.org/supplejack
           <%= link_to t("harvest_jobs.view_details"), environment_enrichment_job_path(abstract_job.environment, abstract_job) %>
         <% end %>
       </td>
-      
+
     </tr>
     <% end %>
   </tbody>

--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -118,7 +118,7 @@ http://digitalnz.org/supplejack
         </h3>
         <div>
           <small>
-            <%= format_backtrace(@harvest_job.harvest_failure.backtrace) %>
+            <%= text_area_tag "", JSON.pretty_generate(JSON.parse(@harvest_job.harvest_failure.backtrace.to_s)), class: 'code-editor-multiple readonly' %>
           </small>
         </div>
       </div>
@@ -126,7 +126,6 @@ http://digitalnz.org/supplejack
   <% end %>
 
   <h5><%= t("harvest_jobs.invalid_records") %> <span class="errors-count">(<%= @harvest_job.invalid_records_count.to_i %>)</span></h5>
-
 
   <% if @harvest_job.invalid_records.any? %>
   <div id="harvest-job-invalid-errors">
@@ -136,7 +135,17 @@ http://digitalnz.org/supplejack
           <span><%= record.error_messages.join(", ") %></span><span class="right"><%= localize_date_time(record.created_at) %></span>
         </h3>
         <div>
-          <%= pretty_format(@harvest_job.parser_id, record.raw_data) %>
+          <h5>Raw Data</h5>
+
+          <% unless record.raw_data.nil? %>
+            <%= text_area_tag "", JSON.pretty_generate(JSON.parse(record.raw_data)), class: 'code-editor-multiple read-only' %>
+          <% end %>
+
+          <h5>Backtrace</h5>
+
+          <% unless record.backtrace.nil? %>
+            <%= text_area_tag "", JSON.pretty_generate(JSON.parse(record.backtrace.to_s)), class: 'code-editor-multiple readonly' %>
+          <% end %>
         </div>
       <% end %>
     </div>
@@ -156,13 +165,16 @@ http://digitalnz.org/supplejack
         </h3>
         <div>
           <h5>Raw Data</h5>
-          <%= text_area_tag "", JSON.pretty_generate(JSON.parse(record.raw_data)), class: 'code-editor-multiple read-only' %>
+
+          <% unless record.raw_data.nil? %>
+            <%= text_area_tag "", JSON.pretty_generate(JSON.parse(record.raw_data)), class: 'code-editor-multiple read-only' %>
+          <% end %>
 
           <h5>Backtrace</h5>
 
-          <%=
-            text_area_tag "", JSON.pretty_generate(JSON.parse(record.backtrace.to_s)), class: 'code-editor-multiple readonly'
-          %>
+          <% unless record.backtrace.nil? %>
+            <%= text_area_tag "", JSON.pretty_generate(JSON.parse(record.backtrace.to_s)), class: 'code-editor-multiple readonly' %>
+          <% end %>
 
         </div>
       <% end %>

--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -1,15 +1,15 @@
-<%#  
+<%#
 The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-and is licensed under the GNU General Public License, version 3. Some components are 
-third party components that are licensed under the MIT license or otherwise publicly available. 
-See https://github.com/DigitalNZ/supplejack_manager for details. 
+and is licensed under the GNU General Public License, version 3. Some components are
+third party components that are licensed under the MIT license or otherwise publicly available.
+See https://github.com/DigitalNZ/supplejack_manager for details.
 
-Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 http://digitalnz.org/supplejack
 %>
 
 <%= content_tag :div, id: "harvest-job", data: { url: harvest_job_path(@harvest_job, format: "js"), active: !@harvest_job.finished? } do %>
-  
+
   <h2 class="left">
     <%= t("harvest_jobs.progress") %>
     <% if can? :update, @harvest_job.parser %>
@@ -93,6 +93,13 @@ http://digitalnz.org/supplejack
       </td>
     </tr>
 
+    <tr>
+      <td><%= t("harvest_jobs.records_retried") %></td>
+      <td>
+        <strong><%= number_with_delimiter @harvest_job.retried_records_count %></strong>
+      </td>
+    </tr>
+
     <% if @harvest_job.status_message.present? %>
     <tr>
       <td><%= t("harvest_jobs.status_message") %></td>
@@ -100,7 +107,7 @@ http://digitalnz.org/supplejack
     </tr>
     <% end %>
   </table>
-  
+
    <% if @harvest_job.harvest_failure.present? %>
     <h5><%= t('harvest_jobs.harvest_failure')%> </h5>
 
@@ -126,7 +133,7 @@ http://digitalnz.org/supplejack
     <div id="accordion-invalid" class="accordion">
       <% @harvest_job.invalid_records.each do |record| %>
         <h3 class="error">
-          <span><%= record.error_messages.join(", ") %></span><span class="right"><%= record.created_at.try(:to_datetime) %></span>
+          <span><%= record.error_messages.join(", ") %></span><span class="right"><%= localize_date_time(record.created_at) %></span>
         </h3>
         <div>
           <%= pretty_format(@harvest_job.parser_id, record.raw_data) %>
@@ -145,10 +152,18 @@ http://digitalnz.org/supplejack
     <div id="accordion-failed" class="accordion">
       <% @harvest_job.failed_records.each do |record| %>
         <h3 class="error">
-          <span><%= record.message %></span><span class="right"><%= record.created_at.try(:to_datetime) %></span>
+          <span><%= record.message %></span><span class="right"><%= localize_date_time(record.created_at) %></span>
         </h3>
         <div>
-          <%= pretty_format(@harvest_job.parser_id, record.raw_data) %>
+          <h5>Raw Data</h5>
+          <%= text_area_tag "", JSON.pretty_generate(JSON.parse(record.raw_data)), class: 'code-editor-multiple read-only' %>
+
+          <h5>Backtrace</h5>
+
+          <%=
+            text_area_tag "", JSON.pretty_generate(JSON.parse(record.backtrace.to_s)), class: 'code-editor-multiple readonly'
+          %>
+
         </div>
       <% end %>
     </div>

--- a/app/views/harvest_jobs/show.js.erb
+++ b/app/views/harvest_jobs/show.js.erb
@@ -1,15 +1,27 @@
-<%#  
+<%#
 The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-and is licensed under the GNU General Public License, version 3. Some components are 
-third party components that are licensed under the MIT license or otherwise publicly available. 
-See https://github.com/DigitalNZ/supplejack_manager for details. 
+and is licensed under the GNU General Public License, version 3. Some components are
+third party components that are licensed under the MIT license or otherwise publicly available.
+See https://github.com/DigitalNZ/supplejack_manager for details.
 
-Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 http://digitalnz.org/supplejack
 %>
 
 $("#harvest-result").html('<%= j render @harvest_job %>').show();
 $("#accordion-failed, #accordion-invalid, #accordion-backtrace").accordion({heightStyle: "content",collapsible: true, active: false})
+
+var code_mirror_text_areas = document.getElementsByClassName('code-editor-multiple');
+
+$(code_mirror_text_areas).each(function(key, value) {
+  CodeMirror.fromTextArea(value, {
+    lineNumbers: true,
+    theme: 'monokai',
+    tabSize: 2,
+    readOnly: true,
+    lineSeperator: ',',
+  })
+});
 
 if ($("#harvest-end-time").length == 0) {
   HarvestJobsPoller.poll()

--- a/app/views/parser_versions/_form.html.erb
+++ b/app/views/parser_versions/_form.html.erb
@@ -1,10 +1,10 @@
-<%#  
+<%#
 The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-and is licensed under the GNU General Public License, version 3. Some components are 
-third party components that are licensed under the MIT license or otherwise publicly available. 
-See https://github.com/DigitalNZ/supplejack_manager for details. 
+and is licensed under the GNU General Public License, version 3. Some components are
+third party components that are licensed under the MIT license or otherwise publicly available.
+See https://github.com/DigitalNZ/supplejack_manager for details.
 
-Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 http://digitalnz.org/supplejack
 %>
 


### PR DESCRIPTION
Acceptance Criteria
=================

Any errors on the jobs list pages have the 'Validation/Failure Errors' value appear in red.
http://harvester.dnz0a.digitalnz.org/production/jobs?status=finished
Error page updated as outlined below

Checklist
=================

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] All Tests are Passing
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Linters Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)