### PR TITLE
REMOVE OLD TAPUHI HARVEST STRATEGY AND CODE FROM SJ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'rails', '~> 3.2.22.2'
 gem 'json', '1.8.3'
 gem 'kgio', '~> 2.10.0'
 
-gem 'supplejack_common', git: 'https://github.com/DigitalNZ/supplejack_common.git', branch: 'rm/remove-tapuhi'
+gem 'supplejack_common', git: 'https://github.com/DigitalNZ/supplejack_common.git'
 # gem 'supplejack_common', path: '/webspace/supplejack/common'
 
 # Due to a bug in multibyte when using Ruby 2.x, we use the ref commit.

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'rails', '~> 3.2.22.2'
 gem 'json', '1.8.3'
 gem 'kgio', '~> 2.10.0'
 
-gem 'supplejack_common', git: 'https://github.com/DigitalNZ/supplejack_common.git'
+gem 'supplejack_common', git: 'https://github.com/DigitalNZ/supplejack_common.git', branch: 'rm/remove-tapuhi'
 # gem 'supplejack_common', path: '/webspace/supplejack/common'
 
 # Due to a bug in multibyte when using Ruby 2.x, we use the ref commit.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/DigitalNZ/supplejack_common.git
-  revision: ab06671360e3bc007478ce96b56a6c1fca1d6d3b
-  branch: rm/remove-tapuhi
+  revision: e8fd0217eb42d8056c1c3bdd89ddc9caa6174804
   specs:
     supplejack_common (0.0.2)
       actionpack (<= 4.1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/DigitalNZ/supplejack_common.git
-  revision: e217f14c5d250a0121f2c9ad15044c49e3af528b
+  revision: ab06671360e3bc007478ce96b56a6c1fca1d6d3b
+  branch: rm/remove-tapuhi
   specs:
     supplejack_common (0.0.2)
       actionpack (<= 4.1.4)
@@ -128,7 +129,7 @@ GEM
       compass (>= 0.12.2, < 0.14)
     concurrent-ruby (1.0.5)
     crack (0.3.2)
-    crass (1.0.2)
+    crass (1.0.3)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -432,4 +433,4 @@ DEPENDENCIES
   zurb-foundation (= 3.2.5)
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -29,9 +29,9 @@ class Parser
   accepts_nested_attributes_for :source
   validates :source, presence: true, associated: true
 
-  VALID_STRATEGIES = ["json", "oai", "rss", "xml", "tapuhi"]
+  VALID_STRATEGIES = ['json', 'oai', 'rss', 'xml']
 
-  VALID_DATA_TYPE = ["record", "concept"]
+  VALID_DATA_TYPE = ['record', 'concept']
 
   # ENVIRONMENTS = [:staging, :production]
   validates_presence_of   :name, :strategy, :data_type
@@ -116,7 +116,7 @@ class Parser
       true
     rescue => error
       self.error = { type: error.class, message: error.message }
-      false    
+      false
     end
   end
 

--- a/spec/controllers/link_check_rules_controller_spec.rb
+++ b/spec/controllers/link_check_rules_controller_spec.rb
@@ -1,19 +1,18 @@
 # The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. Some components are 
-# third party components that are licensed under the MIT license or otherwise publicly available. 
-# See https://github.com/DigitalNZ/supplejack_manager for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+# and is licensed under the GNU General Public License, version 3. Some components are
+# third party components that are licensed under the MIT license or otherwise publicly available.
+# See https://github.com/DigitalNZ/supplejack_manager for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 # http://digitalnz.org/supplejack
 
 require 'spec_helper'
 
 describe LinkCheckRulesController do
-
-  let(:link_check_rule) { mock_model(LinkCheckRule, collection_title: "TAPUHI").as_null_object }
+  let(:link_check_rule) { mock_model(LinkCheckRule, collection_title: 'collection_title').as_null_object }
   let(:user) { mock_model(User).as_null_object }
   let(:admin_user) { mock_model(User, role: 'admin').as_null_object }
-  let(:partner) {FactoryGirl.build(:partner)}
+  let(:partner) { FactoryGirl.build(:partner) }
 
   before(:each) do
     controller.stub(:authenticate_user!) { true }
@@ -21,14 +20,14 @@ describe LinkCheckRulesController do
   end
 
   describe "GET 'index'" do
-    it "should get all of the collection rules" do
+    it 'should get all of the collection rules' do
       LinkCheckRule.should_receive(:all) { [link_check_rule] }
-      get :index, environment: "development"
+      get :index, environment: 'development'
       assigns(:link_check_rules).should eq [link_check_rule]
     end
 
-    it "should do a where if link_check_rules is defined" do
-      params = {link_check_rule: {collection_title: "TAPUHI"}, environment: "development"}
+    it 'should do a where if link_check_rules is defined' do
+      params = {link_check_rule: {collection_title: 'collection_title' }, environment: 'development' }
       LinkCheckRule.should_receive(:where).with(params[:link_check_rule].stringify_keys)
       get :index, params
     end
@@ -37,37 +36,37 @@ describe LinkCheckRulesController do
   describe "GET 'new'" do
     it "creates a new collection rule" do
       LinkCheckRule.should_receive(:new) { link_check_rule }
-      get :new, environment: "development"
+      get :new, environment: 'development'
       assigns(:link_check_rule).should eq link_check_rule
     end
   end
 
   describe "GET 'edit'" do
-    it "loads the partners" do
+    it 'loads the partners' do
       user.should_receive(:admin?).and_return(true)
       Partner.stub_chain(:all, :asc) { [partner] }
       LinkCheckRule.should_receive(:find) { link_check_rule }
-      get :edit, id: link_check_rule.id, environment: "development"
+      get :edit, id: link_check_rule.id, environment: 'development'
       assigns(:partners).should eq [partner]
     end
 
-    it "finds the link_check_rule" do
+    it 'finds the link_check_rule' do
       LinkCheckRule.should_receive(:find) { link_check_rule }
-      get :edit, id: link_check_rule.id, environment: "development"
+      get :edit, id: link_check_rule.id, environment: 'development'
       assigns(:link_check_rule).should eq link_check_rule
     end
   end
 
   describe "POST 'create'" do
-    it "should make a new collection rule and assign it" do
+    it 'should make a new collection rule and assign it' do
       LinkCheckRule.should_receive(:new) { link_check_rule }
-      post :create, link_check_rule: { collection_title: "TAPUHI", status_codes: "203,205" }, environment: "development"
+      post :create, link_check_rule: { collection_title: 'collection_title', status_codes: '203,205' }, environment: "development"
       assigns(:link_check_rule) { link_check_rule }
     end
 
     it "should redirect_to the index page" do
       LinkCheckRule.stub(:new) { link_check_rule }
-      post :create, link_check_rule: { collection_title: "TAPUHI", status_codes: "203,205" }, environment: "development"
+      post :create, link_check_rule: { collection_title: 'collection_title', status_codes: '203,205' }, environment: "development"
       response.should redirect_to environment_link_check_rules_path(environment: "development")
     end
 
@@ -75,7 +74,7 @@ describe LinkCheckRulesController do
       it "should render the new template" do
         LinkCheckRule.stub(:new) { link_check_rule }
         link_check_rule.stub(:save) { false }
-        post :create, link_check_rule: { collection_title: "TAPUHI", status_codes: "203,205" }, environment: "development"
+        post :create, link_check_rule: { collection_title: 'collection_title', status_codes: "203,205" }, environment: "development"
         response.should render_template(:new)
       end
     end
@@ -84,27 +83,27 @@ describe LinkCheckRulesController do
   describe "PUT 'update'" do
     it "should find the link_check_rule" do
       LinkCheckRule.should_receive(:find) { link_check_rule }
-      put :update, id: link_check_rule.id, link_check_rule: { collection_title: "TAPUHI", status_codes: "203,205" }, environment: "development"
+      put :update, id: link_check_rule.id, link_check_rule: { collection_title: 'collection_title', status_codes: "203,205" }, environment: "development"
       assigns(:link_check_rule) { link_check_rule }
     end
 
     it "should redirect_to the index path" do
       LinkCheckRule.stub(:find) { link_check_rule }
-      put :update, id: link_check_rule.id, link_check_rule: { collection_title: "TAPUHI", status_codes: "203,205" }, environment: "development"
+      put :update, id: link_check_rule.id, link_check_rule: { collection_title: 'collection_title', status_codes: "203,205" }, environment: "development"
       response.should redirect_to environment_link_check_rules_path(environment: "development")
     end
 
     it "updates all the attributes" do
       LinkCheckRule.stub(:find) { link_check_rule }
-      link_check_rule.should_receive(:update_attributes).with({"collection_title" => "TAPUHI", "status_codes" => "203,205" })
-      put :update, id: link_check_rule.id, link_check_rule: { collection_title: "TAPUHI", status_codes: "203,205" }, environment: "development"
+      link_check_rule.should_receive(:update_attributes).with({"collection_title" => "collection_title", "status_codes" => "203,205" })
+      put :update, id: link_check_rule.id, link_check_rule: { collection_title: "collection_title", status_codes: "203,205" }, environment: "development"
     end
 
     context "link_check_rule not valid" do
       it "should render the edit template" do
         LinkCheckRule.stub(:find) { link_check_rule }
         link_check_rule.stub(:update_attributes) { false }
-        post :update, id: link_check_rule.id, link_check_rule: { collection_title: "TAPUHI", status_codes: "203,205" }, environment: "development"
+        post :update, id: link_check_rule.id, link_check_rule: { collection_title: "collection_title", status_codes: "203,205" }, environment: "development"
         response.should render_template(:edit)
       end
     end
@@ -119,4 +118,3 @@ describe LinkCheckRulesController do
   end
 
 end
-

--- a/spec/models/collection_statistics_spec.rb
+++ b/spec/models/collection_statistics_spec.rb
@@ -1,9 +1,9 @@
 # The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. Some components are 
-# third party components that are licensed under the MIT license or otherwise publicly available. 
-# See https://github.com/DigitalNZ/supplejack_manager for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+# and is licensed under the GNU General Public License, version 3. Some components are
+# third party components that are licensed under the MIT license or otherwise publicly available.
+# See https://github.com/DigitalNZ/supplejack_manager for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 # http://digitalnz.org/supplejack
 
 require 'spec_helper'
@@ -26,10 +26,10 @@ describe CollectionStatistics do
 	  index_stats.should eq({})
 	end
 
-	@collection_statistics  = { :collection_rules => { source_id: "tapuhi" } }.to_json
+	@collection_statistics  = { :collection_rules => { source_id: "source_id" } }.to_json
 
   ActiveResource::HttpMock.respond_to do |mock|
-    mock.post "/collection_rules.json", {"Authorization" => "Basic MTIzNDU6", "Content-Type" => "application/json"}, @collection_statistics 
+    mock.post "/collection_rules.json", {"Authorization" => "Basic MTIzNDU6", "Content-Type" => "application/json"}, @collection_statistics
   end
 
 	describe "source" do
@@ -41,11 +41,11 @@ describe CollectionStatistics do
       Partner.any_instance.stub(:update_apis)
       Source.any_instance.stub(:update_apis)
       LinkCheckRule.stub(:create)
-      collection_statistics.stub(:source_id) { 'tapuhi' }
+      collection_statistics.stub(:source_id) { 'source_id' }
 		end
 
 		it "shound find the source with the collection statistics source id" do
-			Source.should_receive(:find_by).with(source_id: 'tapuhi') { source }
+			Source.should_receive(:find_by).with(source_id: 'source_id') { source }
 		  collection_statistics.source.should eq source
 		end
 

--- a/spec/models/link_check_rule_spec.rb
+++ b/spec/models/link_check_rule_spec.rb
@@ -1,24 +1,24 @@
 # The majority of The Supplejack Manager code is Crown copyright (C) 2014, New Zealand Government,
-# and is licensed under the GNU General Public License, version 3. Some components are 
-# third party components that are licensed under the MIT license or otherwise publicly available. 
-# See https://github.com/DigitalNZ/supplejack_manager for details. 
-# 
-# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs. 
+# and is licensed under the GNU General Public License, version 3. Some components are
+# third party components that are licensed under the MIT license or otherwise publicly available.
+# See https://github.com/DigitalNZ/supplejack_manager for details.
+#
+# Supplejack was created by DigitalNZ at the National Library of NZ and the Department of Internal Affairs.
 # http://digitalnz.org/supplejack
 
 require "spec_helper"
 
 describe LinkCheckRule do
 	let(:link_check_rule) { LinkCheckRule.new }
-	let(:source) { FactoryGirl.create(:source, source_id: "tapuhi") }
+	let(:source) { FactoryGirl.create(:source, source_id: "source_id") }
 
-	@link_check_rule  = { :link_check_rule => { source_id: "tapuhi", active: true } }.to_json
+	@link_check_rule  = { :link_check_rule => { source_id: "source_id", active: true } }.to_json
 
   ActiveResource::HttpMock.respond_to do |mock|
-    mock.post "/link_check_rule.json", {"Authorization" => "Basic MTIzNDU6", "Content-Type" => "application/json"}, @link_check_rule 
+    mock.post "/link_check_rule.json", {"Authorization" => "Basic MTIzNDU6", "Content-Type" => "application/json"}, @link_check_rule
   end
 
-  before do 
+  before do
     Partner.any_instance.stub(:update_apis)
     Source.any_instance.stub(:update_apis)
     LinkCheckRule.stub(:create)


### PR DESCRIPTION
Check in with PO after initial investigation to identify code
SJ codebase does not contain the Tapuhi harvest strategy or any of its relevant code/DSL.