### PR TITLE
FIX SJ PAUSE & RESUME ISSUE

### DIFF
--- a/app/controllers/harvest_schedules_controller.rb
+++ b/app/controllers/harvest_schedules_controller.rb
@@ -58,7 +58,7 @@ class HarvestSchedulesController < ApplicationController
   end
 
   def update_all
-    HarvestSchedule.all.each do |schedule|
+    HarvestSchedule.all.select { |hs| %w(active stopped).include? hs.status }.each do |schedule|
       schedule.update_attributes(params[:harvest_schedule])
     end
 

--- a/app/views/harvest_schedules/index.html.erb
+++ b/app/views/harvest_schedules/index.html.erb
@@ -18,7 +18,7 @@ http://digitalnz.org/supplejack
     <%= link_to "New Schedule", new_environment_harvest_schedule_path(params[:environment]), class: "button new-right #{can_show_button(:create, HarvestSchedule)}" %>
 
     <%= form_tag update_all_environment_harvest_schedules_path, method: 'put' do %>
-      <%= hidden_field_tag 'harvest_schedule[status]', (@active_jobs ? 'paused' : 'active') %>
+      <%= hidden_field_tag 'harvest_schedule[status]', (@active_jobs ? 'stopped' : 'active') %>
       <%= submit_tag (@active_jobs ? 'Pause All' : 'Resume all'), class: 'button alert new-right' %>
     <% end %>
   </div>  

--- a/spec/controllers/harvest_schedules_controller_spec.rb
+++ b/spec/controllers/harvest_schedules_controller_spec.rb
@@ -20,9 +20,10 @@ describe HarvestSchedulesController do
   describe 'PUT update_all' do
     it 'update the scheduled harvets' do
       expect(HarvestSchedule).to receive(:all) { [schedule] }
-      expect(schedule).to receive(:update_attributes).with({ 'status' => 'paused' })
+      expect(schedule).to receive(:status) { 'active' }
+      expect(schedule).to receive(:update_attributes).with({ 'status' => 'stopped' })
 
-      put :update_all, environment: 'staging', harvest_schedule: { status: 'paused' }
+      put :update_all, environment: 'staging', harvest_schedule: { status: 'stopped' }
     end
   end
 
@@ -49,9 +50,9 @@ describe HarvestSchedulesController do
 
   describe 'POST create' do
     before do
-        stub_request(:post, "http://127.0.0.1:3002/harvest_schedules.json").
+        stub_request(:post, "http://localhost:3002/harvest_schedules.json").
          with(body: "{\"cron\":\"* * * * *\",\"parser_id\":\"1\",\"start_time\":\"2017-11-27 10:29:33 +1300\"}",
-              headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Token token=WORKER_KEY', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}).
+              headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Token token=abcdedfg', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}).
          to_return(status: 200, body: "", headers: {})
       end
 

--- a/spec/controllers/harvest_schedules_controller_spec.rb
+++ b/spec/controllers/harvest_schedules_controller_spec.rb
@@ -22,7 +22,7 @@ describe HarvestSchedulesController do
 
     before do
       expect(schedule).to receive(:status) { 'active' }
-      expect(schedule).to receive(:update_attributes).with({ 'status' => 'stopped' })
+      expect(schedule).to receive(:update_attributes).with({ status:'stopped' })
     end
 
     it 'update the scheduled harvets' do
@@ -33,7 +33,7 @@ describe HarvestSchedulesController do
     it 'does not update individually paused scheduled harvests' do
       expect(HarvestSchedule).to receive(:all) { [schedule, paused_schedule] }
       expect(paused_schedule).to receive(:status) { 'paused' }
-      expect(paused_schedule).to_not receive(:update_attributes).with({ 'status' => 'stopped' })
+      expect(paused_schedule).to_not receive(:update_attributes).with({ status: 'stopped' })
 
       put :update_all, environment: 'staging', harvest_schedule: { status: 'stopped' }
     end

--- a/spec/controllers/harvest_schedules_controller_spec.rb
+++ b/spec/controllers/harvest_schedules_controller_spec.rb
@@ -62,7 +62,7 @@ describe HarvestSchedulesController do
 
   describe 'POST create' do
     before do
-        stub_request(:post, "http://localhost:3002/harvest_schedules.json").
+        stub_request(:post, "http://127.0.0.1:3002/harvest_schedules.json").
          with(body: "{\"cron\":\"* * * * *\",\"parser_id\":\"1\",\"start_time\":\"2017-11-27 10:29:33 +1300\"}",
               headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Token token=WORKER_KEY', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}).
          to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
**Acceptance Criteria**

- Pressing "resume all" after all schedules have been paused does not unpause initially individually paused schedules
- Steps to reproduce
- 
- http://harvester.dnz0a.digitalnz.org/staging/harvest_schedules
- Note the individually paused schedules
- Press "Pause all"
- Press "Resume all"
- Note the original pauses have been lost