### PR TITLE
SJ ENRICHMENTS ARE UNSTOPPABLE

### DIFF
--- a/app/controllers/enrichment_jobs_controller.rb
+++ b/app/controllers/enrichment_jobs_controller.rb
@@ -28,6 +28,7 @@ class EnrichmentJobsController < ApplicationController
   def enrichment_job_params
     params.require(:enrichment_job).permit(:parser_id, :version_id,
                                            :user_id, :environment,
-                                           :record_id, :enrichment)
+                                           :record_id, :enrichment,
+                                           :status)
   end
 end

--- a/spec/controllers/enrichment_jobs_controller_spec.rb
+++ b/spec/controllers/enrichment_jobs_controller_spec.rb
@@ -20,4 +20,15 @@ RSpec.describe EnrichmentJobsController do
       expect(assigns(:enrichment_job)).to eq enrichment_job
     end
   end
+
+  describe 'PUT #update' do
+    it 'checks whether the \'stopped\' parameter is passed to the Enrichment Job' do
+      allow(EnrichmentJob).to receive(:find).and_return(enrichment_job)
+      allow_any_instance_of(EnrichmentJob).to receive(:update_attributes)
+
+      put :update, format: :js, params: { id: 1, environment: 'staging', enrichment_job: attributes_for(:enrichment_job, :stopped) }
+
+      expect(controller.send(:enrichment_job_params)[:status]).to eql 'stopped'
+    end
+  end
 end

--- a/spec/factories/enrichment_job.rb
+++ b/spec/factories/enrichment_job.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
     created_at Time.zone.now
     enrichment 'enrichment_code'
     record_id 1
+
+    trait :stopped do
+      status 'stopped'
+    end
   end
 end


### PR DESCRIPTION
What: Fix stop previewer button bug
Why:  Things are better when they work properly

This change addresses the need by:
* add `stopped` trait to the EnrichmentJob factory
* add `update` action controller spec
* add `status` parameter to the enrichment job strong params list