### PR TITLE
PREPARE FOR API-ONLY MODE ON SJ API

### DIFF
--- a/app/assets/javascripts/admin/activities.js
+++ b/app/assets/javascripts/admin/activities.js
@@ -1,0 +1,3 @@
+$(function() {
+  $('#activities').dataTable();
+});

--- a/app/assets/javascripts/admin/activities.js
+++ b/app/assets/javascripts/admin/activities.js
@@ -1,3 +1,5 @@
 $(function() {
-  $('#activities').dataTable();
+  $('#activities').dataTable({
+    'order': [[ 0, 'desc' ]]
+  });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -39,6 +39,7 @@
 //= require harvest_errors
 //= require admin/users
 //= require collection_statistics
+//= require admin/activities
 
 $(function() {
   $(document).foundation();

--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Admin
+  # app/controllers/admin/activities_controller.rb
+  class ActivitiesController < Admin::ApplicationController
+    respond_to :csv, only: :index
+
+    def index
+      @activities = Admin::Activity.new(params[:environment]).all
+    end
+  end
+end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Admin
+  # app/controllers/admin/application_controller.rb
+  class ApplicationController < ::ApplicationController
+    before_action :authenticate_admin!
+
+    def authenticate_admin!
+      redirect_to root_path unless current_user.admin?
+    end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,9 +2,7 @@
 
 module Admin
   # app/controllers/admin/users_controller.rb
-  class UsersController < ApplicationController
-    before_action :authenticate_admin!
-
+  class UsersController < Admin::ApplicationController
     respond_to :csv, only: :index
 
     def index
@@ -21,10 +19,6 @@ module Admin
       else
         render :edit
       end
-    end
-
-    def authenticate_admin!
-      redirect_to root_path unless current_user.admin?
     end
 
     private

--- a/app/models/admin/activity.rb
+++ b/app/models/admin/activity.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# The admin is pulled from Supplejack API
+# For displaying within the admin section of the Manager
+
+module Admin
+  # app/models/admin/activity.rb
+  class Activity
+    attr_accessor :environment
+
+    def initialize(environment)
+      @environment = environment
+    end
+
+    def all
+      JSON.parse(RestClient.get("#{host}/harvester/activities.json", params: { api_key: api_key }))['site_activities']
+    end
+
+    private
+
+    def host
+      APPLICATION_ENVIRONMENT_VARIABLES[environment]['API_HOST']
+    end
+
+    def api_key
+      APPLICATION_ENVIRONMENT_VARIABLES[environment]['HARVESTER_API_KEY']
+    end
+  end
+end

--- a/app/models/admin/activity.rb
+++ b/app/models/admin/activity.rb
@@ -14,6 +14,8 @@ module Admin
 
     def all
       JSON.parse(RestClient.get("#{host}/harvester/activities.json", params: { api_key: api_key }))['site_activities']
+    rescue Errno::ECONNREFUSED
+      []
     end
 
     private

--- a/app/models/admin/user.rb
+++ b/app/models/admin/user.rb
@@ -14,6 +14,8 @@ module Admin
 
     def all
       @users = JSON.parse(RestClient.get("#{host}/harvester/users.json", params: { api_key: api_key }))['users']
+    rescue Errno::ECONNREFUSED
+      []
     end
 
     def find(id)

--- a/app/views/admin/activities/index.csv.erb
+++ b/app/views/admin/activities/index.csv.erb
@@ -1,0 +1,16 @@
+<%-
+  require 'csv'
+
+  csv_output = CSV.generate(:col_sep => ",") do |csv|
+    columns = ['date', 'search', 'user_sets', 'records', 'source_clicks', 'total']
+
+    csv << columns
+    
+    Admin::Activity.new(params[:environment]).all.each do |site_activity|
+      csv << columns.map do |c|
+        site_activity[c]
+      end
+    end
+  end
+%>
+<%= csv_output.html_safe %>

--- a/app/views/admin/activities/index.html.erb
+++ b/app/views/admin/activities/index.html.erb
@@ -1,0 +1,29 @@
+<h1>API Activities</h1>
+
+<%= link_to('Download CSV', environment_admin_activities_path(format: :csv), class: 'button primary new-right') %>
+
+<table id='activities'>
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Search</th>
+      <th>User Sets</th>
+      <th>Records</th>
+      <th>Source Clickthroughs</th>
+      <th>Total</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @activities.each do |activity| %>
+    <tr>
+      <td><%= activity['date'] %></td>
+      <td><%= number_with_delimiter activity['search'] %></td>
+      <td><%= number_with_delimiter activity['user_sets'] %></td>
+      <td><%= number_with_delimiter activity['records'] %></td>
+      <td><%= number_with_delimiter activity['source_clicks'] %></td>
+      <td><%= number_with_delimiter activity['total'] %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -45,7 +45,7 @@
               <ul class='dropdown menu' data-dropdown-menu>
                 <% APPLICATION_ENVS.reverse.each do |environment| %>
                   <%= link_to "#{environment.capitalize} Users", environment_admin_users_path(environment, page: 1), id: "#{environment}-api-users" %>
-                  <%= link_to "#{environment.capitalize} Activities", environment_admin_activities_path(environment), id: "#{environment}-api-activities" %>
+                  <%= link_to "#{environment.capitalize} API activities", environment_admin_activities_path(environment), id: "#{environment}-api-activities" %>
                 <% end %>
               </ul>
             </li>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -44,7 +44,8 @@
               <%= link_to 'API Admin', '#' %>
               <ul class='dropdown menu' data-dropdown-menu>
                 <% APPLICATION_ENVS.reverse.each do |environment| %>
-                  <%= link_to environment.capitalize, environment_admin_users_path(environment, page: 1), id: "#{environment}-api-users" %>
+                  <%= link_to "#{environment.capitalize} Users", environment_admin_users_path(environment, page: 1), id: "#{environment}-api-users" %>
+                  <%= link_to "#{environment.capitalize} Activities", environment_admin_activities_path(environment), id: "#{environment}-api-activities" %>
                 <% end %>
               </ul>
             </li>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -45,7 +45,7 @@
               <ul class='dropdown menu' data-dropdown-menu>
                 <% APPLICATION_ENVS.reverse.each do |environment| %>
                   <%= link_to "#{environment.capitalize} Users", environment_admin_users_path(environment, page: 1), id: "#{environment}-api-users" %>
-                  <%= link_to "#{environment.capitalize} API activities", environment_admin_activities_path(environment), id: "#{environment}-api-activities" %>
+                  <%= link_to "#{environment.capitalize} API activity", environment_admin_activities_path(environment), id: "#{environment}-api-activities" %>
                 <% end %>
               </ul>
             </li>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -44,8 +44,8 @@
               <%= link_to 'API Admin', '#' %>
               <ul class='dropdown menu' data-dropdown-menu>
                 <% APPLICATION_ENVS.reverse.each do |environment| %>
-                  <%= link_to "#{environment.capitalize} Users", environment_admin_users_path(environment, page: 1), id: "#{environment}-api-users" %>
-                  <%= link_to "#{environment.capitalize} API activity", environment_admin_activities_path(environment), id: "#{environment}-api-activities" %>
+                  <%= link_to "#{environment.capitalize} - Users", environment_admin_users_path(environment, page: 1), id: "#{environment}-api-users" %>
+                  <%= link_to "#{environment.capitalize} - API activity", environment_admin_activities_path(environment), id: "#{environment}-api-activities" %>
                 <% end %>
               </ul>
             </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ HarvesterManager::Application.routes.draw do
   scope ':environment', as: 'environment' do
     namespace :admin do
       resources :users
+      resources :activities, only: [:index]
     end
   end
 

--- a/spec/controllers/admin/activites_controller_spec.rb
+++ b/spec/controllers/admin/activites_controller_spec.rb
@@ -26,10 +26,6 @@ RSpec.describe Admin::ActivitiesController do
       it 'renders the :index template' do
         expect(response).to render_template :index
       end
-
-      it 'assigns an instance of @activities' do
-        expect(assigns(:activities)).to be_a(Admin::Activity)
-      end
     end
 
     context 'csv' do
@@ -43,10 +39,6 @@ RSpec.describe Admin::ActivitiesController do
 
       it 'renders the CSV file' do
         expect(response.header['Content-Type']).to include 'text/csv'
-      end
-
-      it 'assigns an array of @activity objects' do
-        expect(assigns(:activities).first).to be_a(Admin::Activity)
       end
     end
   end

--- a/spec/controllers/admin/activites_controller_spec.rb
+++ b/spec/controllers/admin/activites_controller_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::ActivitesController do
+  describe '#index' do
+    it 'returns a succesfull status code' do
+      get :index
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/admin/activites_controller_spec.rb
+++ b/spec/controllers/admin/activites_controller_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Admin::ActivitiesController do
   end
 
   describe '#index' do
+    before do
+      allow_any_instance_of(Admin::Activity).to receive(:all) { true }
+    end
+
     context 'html' do
       before do
         get :index, params: { environment: 'development' }
@@ -21,6 +25,10 @@ RSpec.describe Admin::ActivitiesController do
 
       it 'renders the :index template' do
         expect(response).to render_template :index
+      end
+
+      it 'assigns an instance of @activities' do
+        expect(assigns(:activities)).to be_a(Admin::Activity)
       end
     end
 
@@ -35,6 +43,10 @@ RSpec.describe Admin::ActivitiesController do
 
       it 'renders the CSV file' do
         expect(response.header['Content-Type']).to include 'text/csv'
+      end
+
+      it 'assigns an array of @activity objects' do
+        expect(assigns(:activities).first).to be_a(Admin::Activity)
       end
     end
   end

--- a/spec/controllers/admin/activites_controller_spec.rb
+++ b/spec/controllers/admin/activites_controller_spec.rb
@@ -2,11 +2,40 @@
 
 require 'rails_helper'
 
-RSpec.describe Admin::ActivitesController do
+RSpec.describe Admin::ActivitiesController do
+  let(:user) { create(:user, :admin, email: 'info@boost.co.nz') }
+
+  before do
+    sign_in(user)
+  end
+
   describe '#index' do
-    it 'returns a succesfull status code' do
-      get :index
-      expect(response).to have_http_status(200)
+    context 'html' do
+      before do
+        get :index, params: { environment: 'development' }
+      end
+
+      it 'returns a succesfull status code' do
+        expect(response).to have_http_status(200)
+      end
+
+      it 'renders the :index template' do
+        expect(response).to render_template :index
+      end
+    end
+
+    context 'csv' do
+      before do
+        get :index, params: { environment: 'development' }, format: :csv
+      end
+
+      it 'renders a succesful status code' do
+        expect(response.status).to eq 200
+      end
+
+      it 'renders the CSV file' do
+        expect(response.header['Content-Type']).to include 'text/csv'
+      end
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,4 +1,3 @@
-
 require 'rails_helper'
 
 describe UsersController do

--- a/spec/models/admin/activity_spec.rb
+++ b/spec/models/admin/activity_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Activity, type: :model do
+  let(:activity) { Admin::Activity.new('development') }
+
+  describe 'attributes' do
+    it 'can be initialized with an environmnet' do
+      expect(activity.environment).to eq 'development'
+    end
+  end
+end


### PR DESCRIPTION
** Acceptance Criteria **

Site Activities pages is moved and works from SJ manager
"site activities" is renamed to "api_activity"
Nav links are as seen in attached screenshot
API is ready for API-only mode to be turned on