### PR TITLE
NEW USER AUTHENTICATION 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,22 +1,22 @@
+# frozen_string_literal: true
 
 class User
   include Mongoid::Document
   include Mongoid::Timestamps
 
-  ROLES = %w[admin user]
+  ROLES = %w[admin user].freeze
 
   default_scope -> { order_by(name: 1) }
   scope :active, -> { where(active: true) }
   scope :deactivated, -> { where(active: false) }
 
   devise :database_authenticatable, :recoverable, :rememberable, :trackable, :validatable
-  before_save :ensure_authentication_token
 
   field :name,                    type: String
 
   ## Database authenticatable
-  field :email,                   type: String,   default: ""
-  field :encrypted_password,      type: String,   default: ""
+  field :email,                   type: String,   default: ''
+  field :encrypted_password,      type: String,   default: ''
 
   ## Recoverable
   field :reset_password_token,    type: String
@@ -32,9 +32,6 @@ class User
   field :current_sign_in_ip,      type: String
   field :last_sign_in_ip,         type: String
 
-  ## Token authenticatable
-  field :authentication_token,    type: String
-
   field :role,                    type: String,   default: 'user'
   field :active,                  type: Boolean,  default: true
 
@@ -47,10 +44,6 @@ class User
 
   validates :name, :email, :role, presence: true
   validates :role, inclusion: ROLES
-
-  def ensure_authentication_token
-    self.authentication_token = SecureRandom.base64 if authentication_token.blank?
-  end
 
   def first_name
     name.split("\s").first if name.present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,14 +10,7 @@ class User
   scope :deactivated, -> { where(active: false) }
 
   devise :database_authenticatable, :recoverable, :rememberable, :trackable, :validatable
-
-  # TODO check if needed. I have commented out because it seems very odd to override the mongo fields with attr_accessor
-  # attr_accessor :name, :email, :password, :password_confirmation, :remember_me,
-  #   :role, :active,
-  #   :manage_data_sources, :manage_parsers, :manage_harvest_schedules, :manage_link_check_rules,
-  #   :manage_partners, :run_harvest_partners
-
-  # before_save :ensure_authentication_token
+  before_save :ensure_authentication_token
 
   field :name,                    type: String
 
@@ -54,6 +47,10 @@ class User
 
   validates :name, :email, :role, presence: true
   validates :role, inclusion: ROLES
+
+  def ensure_authentication_token
+    self.authentication_token = SecureRandom.base64 if authentication_token.blank?
+  end
 
   def first_name
     name.split("\s").first if name.present?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -69,4 +69,19 @@ describe User do
       expect(user.run_harvest_partners).to eq ['a', 'c']
     end
   end
+
+  describe '#ensure_authentication_token' do
+    it 'will generate an authentication token if it is currently empty' do
+      expect(user.authentication_token).to be_nil
+      user.save
+      expect(user.authentication_token).not_to be_nil
+    end
+
+    it 'will not overwrite an existing authentication token' do
+      user.save
+      token = user.authentication_token
+      user.save
+      expect(user.authentication_token).to eq token
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -69,19 +69,4 @@ describe User do
       expect(user.run_harvest_partners).to eq ['a', 'c']
     end
   end
-
-  describe '#ensure_authentication_token' do
-    it 'will generate an authentication token if it is currently empty' do
-      expect(user.authentication_token).to be_nil
-      user.save
-      expect(user.authentication_token).not_to be_nil
-    end
-
-    it 'will not overwrite an existing authentication token' do
-      user.save
-      token = user.authentication_token
-      user.save
-      expect(user.authentication_token).to eq token
-    end
-  end
 end


### PR DESCRIPTION
Acceptance Criteria

Check if this is actually causing anybody any issues. Is this a problem?
Authentication Token is correctly generated when a new SJ user is set up in the manager.

** Notes **

This is a hang over from when we upgraded Devise and the authentication token authorization was removed. We have since updated how authentication works but this was left behind.