### PR TITLE
SJ COLLECTION STATUS INTERFACE TWEAKS: As a harvest operator I want the collection status page to be as clear as possible, so I can understand the information at a glance

### DIFF
--- a/app/views/suppress_collections/index.html.erb
+++ b/app/views/suppress_collections/index.html.erb
@@ -35,7 +35,7 @@
     <tr>
       <td><%= source['name'] %></td>
       <td><%= source['status_updated_by'] %></td>
-      <td><%= source['status_updated_at'].try(:to_datetime).try(:strftime, '%m/%d/%Y %I:%M%p') %></td>
+      <td><%= source['status_updated_at'].try(:to_datetime).try(:strftime, '%d/%m/%Y %I:%M%p') %></td>
       <% if can? :update, :suppress_collection %>
         <td>
           <%= form_tag(environment_suppress_collection_path(id: source["_id"], environment: params[:environment]), {method: :put, id: "suppress_collection"}) do |f| %>
@@ -58,7 +58,7 @@
     <% @top_10_sources.each do |source| %>
     <tr>
       <td>
-        <strong><%= source['name'] %></strong> was activated by <strong><%= source['status_updated_by'] %></strong> at <strong><%= source['status_updated_at'].try(:to_datetime).try(:strftime, '%m/%d/%Y %I:%M%p') %></strong></td>
+        <strong><%= source['name'] %></strong> was activated by <strong><%= source['status_updated_by'] %></strong> at <strong><%= source['status_updated_at'].try(:to_datetime).try(:strftime, '%d/%m/%Y %I:%M%p') %></strong></td>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/suppress_collections/index.html.erb
+++ b/app/views/suppress_collections/index.html.erb
@@ -22,7 +22,7 @@
 <table>
   <thead>
     <tr>
-      <th><%= t('link_checker.suppress_collections.collection_title') %></th>
+      <th><%= t('link_checker.suppress_collections.source_id') %></th>
       <th><%= t('link_checker.suppress_collections.status_updated_by') %></th>
       <th><%= t('link_checker.suppress_collections.status_updated_at') %></th>
       <% if can? :update, :suppress_collection %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -133,7 +133,7 @@ en:
       helptext: "A collection is a set of harvested data that has come from a specific data source. You can suppress a collection (i.e. all records associated with a specific data source) from the active search index by selecting the matching data source."
       current_supressions_title: "Currently suppressed collections"
       latest_activated_collections: "Recently activated collections"
-      collection_title: "Collection Title"
+      source_id: "Source ID"
       status_updated_by: "Status updated by"
       status_updated_at: "Status updated at"
       suppress_a: "Suppress a Collection"


### PR DESCRIPTION
**Acceptance Criteria**
- The first column title "Collection Title" is changed to "Source ID"
- All dates are displayed as d/m/y

*Notes*
- http://harvester.dnz0a.digitalnz.org/production/suppress_collections