### PR TITLE
CLEAN UP GHOST LINK CHECK RULES

### DIFF
--- a/app/controllers/link_check_rules_controller.rb
+++ b/app/controllers/link_check_rules_controller.rb
@@ -7,7 +7,7 @@ class LinkCheckRulesController < ApplicationController
   load_and_authorize_resource
 
   def index
-    @link_check_rules = params[:link_check_rule].present? ? LinkCheckRule.where(params[:link_check_rule]) : LinkCheckRule.all
+    @link_check_rules = params[:link_check_rule].present? ? LinkCheckRule.where(params[:link_check_rule]) : LinkCheckRule.all.select(&:source)
     respond_with @link_check_rules
   end
 

--- a/spec/controllers/link_check_rules_controller_spec.rb
+++ b/spec/controllers/link_check_rules_controller_spec.rb
@@ -25,6 +25,13 @@ describe LinkCheckRulesController do
       expect(LinkCheckRule).to receive(:where).with(params[:link_check_rule].stringify_keys)
       get :index, params: params
     end
+
+    it 'should not retrieve any link check rules without a source' do
+      allow(Source).to receive(:find) { nil }
+      expect(LinkCheckRule).to receive(:all) { Array.new }
+      get :index, params: { environment: 'development' }
+      expect(assigns(:link_check_rules)).to eq Array.new
+    end
   end
 
   describe "GET 'new'" do

--- a/spec/controllers/link_check_rules_controller_spec.rb
+++ b/spec/controllers/link_check_rules_controller_spec.rb
@@ -5,13 +5,16 @@ describe LinkCheckRulesController do
   let(:link_check_rule) { build(:link_check_rule) }
   let(:user)            { create(:user, :admin) }
   let(:partner)         { build(:partner) }
+  let(:source)          { build(:source) }
 
   before(:each) do
+    allow_any_instance_of(Source).to receive(:update_apis)
     sign_in user
   end
 
   describe "GET 'index'" do
-    it 'should get all of the collection rules' do
+    it 'should get all of the valid collection rules' do
+      allow(Source).to receive(:find) { source }
       expect(LinkCheckRule).to receive(:all) { [link_check_rule] }
       get :index, params: { environment: 'development' }
       expect(assigns(:link_check_rules)).to eq [link_check_rule]

--- a/spec/factories/sources.rb
+++ b/spec/factories/sources.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :source do
     sequence(:name) {|n| "A Source #{n}" }
     sequence(:source_id) {|n| "source_#{n}"}
-    partner
+    partner { build(:partner) }
   end
 end


### PR DESCRIPTION
What: Link Check Rule controller index action refactoring
Why:  Fetch only Link Check rules that have a source attached

This change addresses the need by:
* Add logic around LinkCheckRule to select all `LinkCheckRule`s that have a source