### PR TITLE
PREVENT ILLEGAL PARSER NAMES: As Tonya I want to be informed and blocked from entering any illegal characters in a new parser name, so that the parser does not save fine while silently failing to preview or run

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -1,6 +1,12 @@
 .error {
   small {
     color: $alert-color;
+    display: block;
+    margin-bottom: 1rem;
+  }
+
+  input, select {
+    margin-bottom: .5rem;
   }
 }
 

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -1,4 +1,8 @@
-
+.error {
+  small {
+    color: red;
+  }
+}
 
 select {
   margin-bottom: 12px;

--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -1,6 +1,6 @@
 .error {
   small {
-    color: red;
+    color: $alert-color;
   }
 }
 

--- a/app/controllers/parsers_controller.rb
+++ b/app/controllers/parsers_controller.rb
@@ -41,10 +41,10 @@ class ParsersController < ApplicationController
     @source = @parser.source
 
     @partners = if can? :manage, Partner
-              Partner.asc(:name)
-            else
-              Partner.where(:id.in => current_user.manage_partners).asc(:name)
-            end
+                  Partner.asc(:name)
+                else
+                  Partner.where(:id.in => current_user.manage_partners).asc(:name)
+                end
 
     if @parser.save
       redirect_to edit_parser_path(@parser)

--- a/app/controllers/parsers_controller.rb
+++ b/app/controllers/parsers_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ParsersController < ApplicationController
   load_and_authorize_resource
 
@@ -8,7 +10,9 @@ class ParsersController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.json { render json: @parsers, serializer: ActiveModel::ArraySerializer }
+      format.json do
+        render json: @parsers, serializer: ActiveModel::ArraySerializer
+      end
     end
   end
 
@@ -20,11 +24,11 @@ class ParsersController < ApplicationController
     @source = @parser.source = Source.new
     @source.partner = Partner.new
 
-    if can? :manage, Partner
-      @partners = Partner.asc(:name)
-    else
-      @partners = Partner.where(:id.in => current_user.manage_partners).asc(:name)
-    end
+    @partners = if can? :manage, Partner
+                  Partner.asc(:name)
+                else
+                  Partner.where(:id.in => current_user.manage_partners).asc(:name)
+                end
   end
 
   def edit
@@ -35,6 +39,12 @@ class ParsersController < ApplicationController
   def create
     @parser.user_id = current_user.id
     @source = @parser.source
+
+    @partners = if can? :manage, Partner
+              Partner.asc(:name)
+            else
+              Partner.where(:id.in => current_user.manage_partners).asc(:name)
+            end
 
     if @parser.save
       redirect_to edit_parser_path(@parser)
@@ -65,8 +75,8 @@ class ParsersController < ApplicationController
 
     if @parser.save
       if params[:allow] == 'false'
-        HarvestSchedule.update_schedulers_from_environment({parser_id: @parser.id}, "staging")
-        HarvestSchedule.update_schedulers_from_environment({parser_id: @parser.id}, "production")
+        HarvestSchedule.update_schedulers_from_environment({parser_id: @parser.id}, 'staging')
+        HarvestSchedule.update_schedulers_from_environment({parser_id: @parser.id}, 'production')
       end
       respond_to do |format|
         format.html { redirect_to edit_parser_path(@parser) }

--- a/app/controllers/parsers_controller.rb
+++ b/app/controllers/parsers_controller.rb
@@ -54,11 +54,9 @@ class ParsersController < ApplicationController
   end
 
   def update
-    @parser.attributes = parser_params
-    @parser.user_id = current_user.id
-    @parser.update_contents_parser_class!
+    if @parser.update(parser_params.merge('user_id' => current_user.id))
+      @parser.update_contents_parser_class!
 
-    if @parser.save
       redirect_to edit_parser_path(@parser)
     else
       render :edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
 
       if needs_password?(@user, params)
         if @user.update_attributes(user_params)
-          sign_in(@user, bypass: true) if @user == current_user
+          bypass_sign_in(@user) if @user == current_user
           redirect_to safe_users_path, notice: 'User was successfully updated.'
         else
           render :edit

--- a/app/models/concerns/parser/template_helpers.rb
+++ b/app/models/concerns/parser/template_helpers.rb
@@ -4,11 +4,10 @@ class Parser
 		extend ActiveSupport::Concern
 
 		def update_contents_parser_class!
-	    if self.changed.include?("name")
-	      class_name = self.name.gsub(/\s/, "_").camelize
-	      self.content = self.content.gsub(/^class .* </, "class #{class_name} <")
-	      self.message = "Renamed parser class"
-	    end
+      class_name = name.gsub(/\s/, '_').camelize
+      self.content = content.gsub(/^class .* </, "class #{class_name} <")
+      self.message = 'Renamed parser class'
+      self.save
 	  end
 
 	  def apply_parser_template!

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -42,7 +42,7 @@ class Parser
     class_name.constantize
   rescue NameError => e
     if e.message.include? 'wrong constant name'
-      errors.add(:name, 'Your Parser Name includes invalid characters. Please only use Alphabetical or Numberic characters.')
+      errors.add(:name, 'Your Parser Name includes invalid characters. Please only use Alphabetical or Numeric characters.')
     end
   end
 

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -32,17 +32,31 @@ class Parser
   validates_inclusion_of  :strategy, in: VALID_STRATEGIES
   validates_inclusion_of  :data_type, in: VALID_DATA_TYPE
 
+  validate :parser_name_is_a_valid_class_name
+
   before_create :apply_parser_template!
 
   before_destroy { |parser| HarvestSchedule.destroy_all_for_parser(parser.id) }
+
+  def parser_name_is_a_valid_class_name
+    class_name.constantize
+  rescue NameError => e
+    if e.message.include? 'wrong constant name'
+      errors.add(:name, 'Your Parser Name includes invalid characters. Please only use Alphabetical or Numberic characters.')
+    end
+  end
 
   def self.find_by_partners(partner_ids=[])
     sources = Source.where(:partner.in => partner_ids).pluck(:id)
     @parsers = Parser.where(:source.in => sources)
   end
 
+  def class_name
+    name.gsub(/\s/, '').camelize
+  end
+
   def file_name
-    @file_name ||= self.name.downcase.gsub(/\s/, "_") + ".rb"
+    @file_name ||= name.downcase.gsub(/\s/, '_') + ".rb"
   end
 
   def path
@@ -52,7 +66,6 @@ class Parser
   def running_jobs?
     begin
       active_jobs = []
-
       APPLICATION_ENVS.each do |environment|
         active_jobs << AbstractJob.search({parser_id: self.id}, environment)
       end

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -39,6 +39,7 @@ class Parser
   before_destroy { |parser| HarvestSchedule.destroy_all_for_parser(parser.id) }
 
   def parser_name_is_a_valid_class_name
+    errors.add(:name, 'Your Parser Name includes invalid characters. Please remove the /.') if name.include? '/'
     class_name.constantize
   rescue NameError => e
     if e.message.include? 'wrong constant name'

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -43,7 +43,7 @@ class Parser
     class_name.constantize
   rescue NameError => e
     if e.message.include? 'wrong constant name'
-      errors.add(:name, 'Your Parser Name includes invalid characters. Please only use Alphabetical or Numeric characters.')
+      errors.add(:name, 'Parser name includes invalid characters. The name can only contain Alphabetical or Numeric characters, and can not start with a number.')
     end
   end
 

--- a/app/views/parsers/_parser.html.erb
+++ b/app/views/parsers/_parser.html.erb
@@ -3,11 +3,13 @@
 <div class="grid-x grid-margin-x">
   <div class="medium-9 cell">
     <% if can? :update, @parser %>
-      <h1 id="parser-title" class="float-left">
-        <%= link_to @parser.name, edit_parser_path(@parser) %>
-        <span class="parser-tag <%= "alert" if @parser.data_type == "concept" %> round label"><%= @parser.data_type %></span>
-      </h1>
-      <div id="hidden-parser-form">
+      <% if @parser.errors.blank? %>
+        <h1 id="parser-title" class="float-left">
+          <%= link_to @parser.name, edit_parser_path(@parser) %>
+          <span class="parser-tag <%= "alert" if @parser.data_type == "concept" %> round label"><%= @parser.data_type %></span>
+        </h1>
+      <% end %>
+      <div id="<%= 'hidden-parser-form' if @parser.errors.empty? %>">
         <%= simple_form_for @parser do |f| %>
           <div class='parser-form'>
             <%= f.input :name %>
@@ -19,9 +21,7 @@
       <h1 id="parser-title" class="float-left"><%= @parser.name %></h1>
     <% end %>
   </div>
-
   <div class="medium-3 cell">
-
   </div>
 </div>
 <div class="grid-x grid-margin-x">

--- a/app/views/parsers/new.html.erb
+++ b/app/views/parsers/new.html.erb
@@ -11,7 +11,7 @@
     <div class="grid-x">
       <div class="medium-12 cell">
         <%= f.input :name %>
-        <%= f.input :partner, collection: @partners, value_method: :name %>
+        <%= f.input :partner, collection: @partners, value_method: :name, selected: params.try(:[], 'parser').try(:[], 'partner') %>
         <%= f.association :source, as: :grouped_select, collection: @partners, group_method: :sources, label_method: :name %>
         <%= f.input :strategy, collection: Hash[Parser::VALID_STRATEGIES.map { |u| [(u == 'xml' ? "#{u}/html".upcase : u.upcase), u]  }] %>
         <% if parser_type_enabled %>

--- a/spec/controllers/parsers_controller_spec.rb
+++ b/spec/controllers/parsers_controller_spec.rb
@@ -102,8 +102,8 @@ describe ParsersController do
     end
 
     it "updates the parser attributes" do
-      expect(parser).to receive('attributes=').with({'name' => 'Tepapa'})
       put :update, params: { id: '1234', parser: { name: 'Tepapa' } }
+      expect(parser.name).to eq 'Tepapa'
     end
 
     it 'saves the parser' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -115,7 +115,7 @@ describe UsersController do
       end
 
       it 'should sign in if the user is the current user' do
-        expect(controller).to receive(:sign_in)
+        expect(controller).to receive(:bypass_sign_in)
         put :update, params: { id: user.id, user: { name: 'User' } }
       end
 

--- a/spec/models/parser_spec.rb
+++ b/spec/models/parser_spec.rb
@@ -34,12 +34,26 @@ describe Parser do
       parser2 = build(:parser, name: parser.name)
       expect(parser2).not_to be_valid
     end
+
+    it 'must have a name that can be used as a class name' do
+      parser3 = build(:parser, name: "Hey'bro!")
+      parser3.valid?
+      expect(parser3.errors.messages[:name].first).to eq 'Your Parser Name includes invalid characters. Please only use Alphabetical or Numberic characters.'
+      expect(parser3).not_to be_valid
+    end
   end
 
   describe "before:destroy" do
     it "should destroy all HarvestSchedules for the given parser." do
       expect(HarvestSchedule).to receive(:destroy_all_for_parser).with(parser.id)
       parser.destroy
+    end
+  end
+
+  describe '.parser_class_name' do
+    it 'returns the parser name as a class name' do
+      parser = build(:parser, name: 'nZ Museums')
+      expect(parser.class_name).to eq 'NZMuseums'
     end
   end
 

--- a/spec/models/parser_spec.rb
+++ b/spec/models/parser_spec.rb
@@ -38,7 +38,7 @@ describe Parser do
     it 'must have a name that can be used as a class name' do
       parser3 = build(:parser, name: "Hey'bro!")
       parser3.valid?
-      expect(parser3.errors.messages[:name].first).to eq 'Your Parser Name includes invalid characters. Please only use Alphabetical or Numeric characters.'
+      expect(parser3.errors.messages[:name].first).to eq 'Parser name includes invalid characters. The name can only contain Alphabetical or Numeric characters, and can not start with a number.'
       expect(parser3).not_to be_valid
     end
 

--- a/spec/models/parser_spec.rb
+++ b/spec/models/parser_spec.rb
@@ -38,7 +38,7 @@ describe Parser do
     it 'must have a name that can be used as a class name' do
       parser3 = build(:parser, name: "Hey'bro!")
       parser3.valid?
-      expect(parser3.errors.messages[:name].first).to eq 'Your Parser Name includes invalid characters. Please only use Alphabetical or Numberic characters.'
+      expect(parser3.errors.messages[:name].first).to eq 'Your Parser Name includes invalid characters. Please only use Alphabetical or Numeric characters.'
       expect(parser3).not_to be_valid
     end
   end

--- a/spec/models/parser_spec.rb
+++ b/spec/models/parser_spec.rb
@@ -41,6 +41,13 @@ describe Parser do
       expect(parser3.errors.messages[:name].first).to eq 'Your Parser Name includes invalid characters. Please only use Alphabetical or Numeric characters.'
       expect(parser3).not_to be_valid
     end
+
+    it 'cannot have slashes in the class name' do
+      parser4 = build(:parser, name: 'Jeu/asd')
+      parser4.valid?
+      expect(parser4.errors.messages[:name].first).to eq 'Your Parser Name includes invalid characters. Please remove the /.'
+      expect(parser4).not_to be_valid
+    end
   end
 
   describe "before:destroy" do
@@ -50,7 +57,7 @@ describe Parser do
     end
   end
 
-  describe '.parser_class_name' do
+  describe '.class_name' do
     it 'returns the parser name as a class name' do
       parser = build(:parser, name: 'nZ Museums')
       expect(parser.class_name).to eq 'NZMuseums'


### PR DESCRIPTION
**Acceptance Criteria**
- New parser name field does not accept/save when illegal characters are present
- Harvester is informed of what characters are (or are not) allowed to be used and asked to change before the parser/form is saved

**Notes**
- If you use macrons or full stops (or probably other illegal char's) in a parser name, it will silently fail to do anything (eg preview or harvest). Form needs some validation warnings and/or hint text in the new parser form that helps prevent this problem
http://harvester.dnz0a.cloud.digitalnz.org/parsers/new