### PR TITLE
REMOVE THE WHOLE CONCEPT FROM 'SOURCE NAMES' IN SJ

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -54,6 +54,6 @@ class SourcesController < ApplicationController
   end
 
   def source_params
-    params.require(:source).permit(:name, :source_id, :partner_id, partner_attributes: :name)
+    params.require(:source).permit(:source_id, :partner_id, partner_attributes: :name)
   end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -15,7 +15,7 @@ class Partner
   def self.for_select
     return [] if Partner.all.empty?
     Partner.all.sort(name: 1).map do |partner|
-      [partner.name, partner.sources.map {|p| [p.name, p.id]}]
+      [partner.name, partner.sources.map {|p| [p.source_id, p.id]}]
     end
   end
 

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -5,20 +5,18 @@ class Source
 
   belongs_to :partner
 
-  field :name, type: String
   field :source_id, type: String
 
-  validates :name,      presence: true, uniqueness: true
   validates :source_id, presence: true, uniqueness: true
   validates :partner,   presence: true, associated: true
 
   accepts_nested_attributes_for :partner
 
-  before_validation :create_source_id
-
   after_create :create_link_check_rule
 
   after_save :update_apis
+
+  before_save :slugfy_source_id
 
   def partner_name
     partner.name
@@ -41,7 +39,7 @@ class Source
     end
   end
 
-  def create_source_id
-    self.source_id = self.name.gsub(/[^0-9a-z ]/i, '').split.join("_").downcase unless self.source_id.present?
+  def slugfy_source_id
+    self.source_id = source_id.parameterize.underscore
   end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -16,7 +16,7 @@ class Source
 
   after_save :update_apis
 
-  before_save :slugfy_source_id
+  before_save :slugify_source_id
 
   def partner_name
     partner.name
@@ -39,7 +39,7 @@ class Source
     end
   end
 
-  def slugfy_source_id
+  def slugify_source_id
     self.source_id = source_id.parameterize.underscore
   end
 end

--- a/app/serializers/source_serializer.rb
+++ b/app/serializers/source_serializer.rb
@@ -1,4 +1,4 @@
 
 class SourceSerializer < ActiveModel::Serializer
-  attributes :id, :name, :source_id
+  attributes :id, :source_id
 end

--- a/app/views/collection_statistics/show.html.erb
+++ b/app/views/collection_statistics/show.html.erb
@@ -16,7 +16,7 @@
 <% @collection_statistics.each do |collection| %>
 	<div class="grid-x">
 		<div class="medium-12 cell">
-		<h4><%= collection.source.name %></h4>
+		<h4><%= collection.source.source_id %></h4>
   		<div class="status-section float-left medium-4 cell">
 		    <h5>Activations (<%= collection.activated_records.to_a.size %>)</h5>
 		    <ul class="no-list-style">

--- a/app/views/link_check_rules/_form.html.erb
+++ b/app/views/link_check_rules/_form.html.erb
@@ -1,7 +1,7 @@
 
 
 <%= simple_form_for @link_check_rule, url: url do |f| %>
-  <%= f.input :source_id, as: :grouped_select, collection: @partners, group_method: :sources, label_method: :name, group_label_method: :name %>
+  <%= f.input :source_id, as: :grouped_select, collection: @partners, group_method: :sources, label_method: :source_id, group_label_method: :name %>
   <%= f.input :xpath %>
   <%= f.input :status_codes %>
   <%= f.input :throttle %>

--- a/app/views/link_check_rules/_form.html.erb
+++ b/app/views/link_check_rules/_form.html.erb
@@ -1,7 +1,7 @@
 
 
 <%= simple_form_for @link_check_rule, url: url do |f| %>
-  <%= f.input :source_id, as: :grouped_select, collection: @partners, group_method: :sources, label_method: :name, group_label_method: :name %>
+  <%= f.input :source_id, as: :grouped_select, collection: @partners, group_method: :sources, label_method: :source_id, group_label_method: :source_id %>
   <%= f.input :xpath %>
   <%= f.input :status_codes %>
   <%= f.input :throttle %>

--- a/app/views/link_check_rules/_form.html.erb
+++ b/app/views/link_check_rules/_form.html.erb
@@ -1,7 +1,7 @@
 
 
 <%= simple_form_for @link_check_rule, url: url do |f| %>
-  <%= f.input :source_id, as: :grouped_select, collection: @partners, group_method: :sources, label_method: :source_id, group_label_method: :source_id %>
+  <%= f.input :source_id, as: :grouped_select, collection: @partners, group_method: :sources, label_method: :name, group_label_method: :name %>
   <%= f.input :xpath %>
   <%= f.input :status_codes %>
   <%= f.input :throttle %>

--- a/app/views/link_check_rules/edit.html.erb
+++ b/app/views/link_check_rules/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="grid-x">
   <div class="medium-8 cell">
-    <h2 id="link-check-rule-title" class="left"><%= @link_check_rule.source.name %></h2>
+    <h2 id="link-check-rule-title" class="left"><%= @link_check_rule.source.source_id %></h2>
     <%= render 'form', url: environment_link_check_rule_path(id: @link_check_rule.id, environment: params[:environment]) %>
   </div>
 </div>

--- a/app/views/link_check_rules/index.html.erb
+++ b/app/views/link_check_rules/index.html.erb
@@ -8,7 +8,6 @@
   <thead>
     <tr>
       <th>Partner</th>
-      <th>Source Name</th>
       <th>Source ID</th>
       <th>Active?</th>
       <th>Updated At</th>
@@ -22,12 +21,11 @@
       <td><%= link_check_rule.source.try(:partner_name) %></td>
       <td>
         <% if link_check_rule.source && can?(:update, link_check_rule.source) %>
-          <%= link_to link_check_rule.source.try(:name), edit_source_path(link_check_rule.source) %>
+          <%= link_to link_check_rule.source.try(:source_id), edit_source_path(link_check_rule.source) %>
         <% else %>
-          <%= link_check_rule.source.try(:name) %>
+          <%= link_check_rule.source.try(:source_id) %>
         <% end %>
       </td>
-      <td><%= link_check_rule.source.try(:source_id) %></td>
       <td><%= link_check_rule.active %></td>
       <td><%= DateTime.parse(link_check_rule.updated_at).to_formatted_s(:long) %></td>
       <td>

--- a/app/views/parsers/_parser.html.erb
+++ b/app/views/parsers/_parser.html.erb
@@ -160,7 +160,7 @@
   <p> Warning: changing the source of this parser does not affect records that have already been harvested.</p>
   <%= simple_form_for @parser do |f| %>
     <%= f.input :partner, selected: @parser.partner.name, collection: Partner.all.sort(name: 1), label_method: :name, value_method: :name %>
-    <%= f.association :source, as: :grouped_select, collection: Partner.all, group_method: :sources, include_blank: false, label_method: :name, group_label_method: :name %>
+    <%= f.association :source, as: :grouped_select, collection: Partner.all, group_method: :sources, include_blank: false, label_method: :source_id, group_label_method: :name %>
     <%= f.button :submit, "Change source", class: 'right' %>
   <% end %>
   <button class="close-button" data-close aria-label="Close modal" type="button">

--- a/app/views/parsers/index.html.erb
+++ b/app/views/parsers/index.html.erb
@@ -23,7 +23,7 @@
           <td><%= link_to parser.name, edit_parser_path(parser) %></td>
           <td><%= parser.strategy %></td>
           <td><%= link_to parser.source.partner.name, edit_partner_path(parser.source.partner) %></td>
-          <td><%= link_to parser.source.name, edit_source_path(parser.source) %></td>
+          <td><%= link_to parser.source.source_id, edit_source_path(parser.source) %></td>
           <td><%= parser.versions.last.try(:created_at).try(:localtime)&.to_formatted_s(:long) %></td>
           <td><%= parser.last_edited_by %></td>
           <td><%= parser.data_type %></td>
@@ -33,7 +33,7 @@
           <td><%= link_to parser.name, parser_path(parser) %></td>
           <td><%= parser.strategy %></td>
           <td><%= parser.source.partner.name %></td>
-          <td><%= parser.source.name %></td>
+          <td><%= parser.source.source_id %></td>
           <td><%= parser.versions.last.try(:created_at).try(:localtime)&.to_formatted_s(:long) %></td>
           <td><%= parser.last_edited_by %></td>
           <td><%= parser.data_type %></td>

--- a/app/views/parsers/new.html.erb
+++ b/app/views/parsers/new.html.erb
@@ -12,7 +12,7 @@
       <div class="medium-12 cell">
         <%= f.input :name %>
         <%= f.input :partner, collection: @partners, value_method: :name, selected: params.try(:[], 'parser').try(:[], 'partner') %>
-        <%= f.association :source, as: :grouped_select, collection: @partners, group_method: :sources, label_method: :name %>
+        <%= f.association :source, as: :grouped_select, collection: @partners, group_method: :sources, label_method: :source_id %>
         <%= f.input :strategy, collection: Hash[Parser::VALID_STRATEGIES.map { |u| [(u == 'xml' ? "#{u}/html".upcase : u.upcase), u]  }] %>
         <% if parser_type_enabled %>
           <%= f.input :data_type, collection: Parser::VALID_DATA_TYPE, include_blank: false %>

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -4,12 +4,11 @@
 
   <% if @source.errors.any? %>
     <%= f.error_notification %>
-    <% @source.errors.messages[:name] = @source.errors.messages.delete(:source_id) %>
   <% end %>
 
   <div class="grid-x form-inputs">
     <div class="medium-12 cell">
-      <%= f.input :name %>
+      <%= f.input :source_id, disabled: @source.persisted? %>
       <% if can? :manage, Partner %>
         <%= f.association :partner, collection: @partners, include_blank: '<create new>' %>
         <%= f.simple_fields_for :partner do |partner_form| %>

--- a/app/views/sources/index.html.erb
+++ b/app/views/sources/index.html.erb
@@ -25,7 +25,6 @@
         </tr>
       <% else %>
         <tr>
-          <td><%= source.name %></td>
           <td><%= source.source_id %></td>
           <td><%= source.partner.name %></td>
         </tr>

--- a/app/views/sources/index.html.erb
+++ b/app/views/sources/index.html.erb
@@ -6,7 +6,6 @@
 <table id="sources" class="twelve">
   <thead>
     <tr>
-      <th>Source Name</th>
       <th>Source ID</th>
       <th>Partner</th>
     </tr>
@@ -15,8 +14,7 @@
     <% @sources.each do |source| %>
       <% if can? :update, source %>
         <tr>
-          <td><%= link_to source.name, edit_source_path(source) %></td>
-          <td><%= source.source_id %></td>
+          <td><%= link_to source.source_id, edit_source_path(source) %></td>
           <% if can? :update, source.partner %>
             <td><%= link_to source.partner.name, edit_partner_path(source.partner) %></td>
           <% else %>

--- a/app/views/suppress_collections/index.html.erb
+++ b/app/views/suppress_collections/index.html.erb
@@ -33,7 +33,7 @@
   <tbody>
     <% @blacklisted_sources.each do |source| %>
     <tr>
-      <td><%= source['name'] %></td>
+      <td><%= source['source_id'] %></td>
       <td><%= source['status_updated_by'] %></td>
       <td><%= source['status_updated_at'].try(:to_datetime).try(:strftime, '%d/%m/%Y %I:%M%p') %></td>
       <% if can? :update, :suppress_collection %>

--- a/app/views/suppress_collections/index.html.erb
+++ b/app/views/suppress_collections/index.html.erb
@@ -58,7 +58,7 @@
     <% @top_10_sources.each do |source| %>
     <tr>
       <td>
-        <strong><%= source['name'] %></strong> was activated by <strong><%= source['status_updated_by'] %></strong> at <strong><%= source['status_updated_at'].try(:to_datetime).try(:strftime, '%d/%m/%Y %I:%M%p') %></strong></td>
+        <strong><%= source['source_id'] %></strong> was activated by <strong><%= source['status_updated_by'] %></strong> at <strong><%= source['status_updated_at'].try(:to_datetime).try(:strftime, '%d/%m/%Y %I:%M%p') %></strong></td>
     </tr>
     <% end %>
   </tbody>

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require 'rails_helper'
 
@@ -22,36 +23,36 @@ describe SourcesController do
   describe 'GET index' do
     it 'assigns all sources as @sources' do
       source = Source.create! valid_attributes
-      get :index, {}
+      get :index
       expect(assigns(:sources)).to eq([source])
     end
   end
 
-  describe "GET new" do
-    it "assigns a new source as @source" do
-      get :new, {}
+  describe 'GET new' do
+    it 'assigns a new source as @source' do
+      get :new
       expect(assigns(:source)).to be_a_new(Source)
     end
   end
 
-  describe "GET edit" do
-    it "assigns the requested source as @source" do
+  describe 'GET edit' do
+    it 'assigns the requested source as @source' do
       source = Source.create! valid_attributes
-      get :edit, params: { id:  source.to_param }
+      get :edit, params: { id: source.to_param }
       expect(assigns(:source)).to eq(source)
     end
   end
 
-  describe "POST create" do
-    before(:each) {
+  describe 'POST create' do
+    before(:each) do
       allow(controller).to receive(:current_user) { build(:user, role: 'admin') }
-    }
+    end
 
     describe 'with valid params' do
       it 'creates a new Source' do
-        expect {
+        expect do
           post :create, params: { source: valid_attributes }
-        }.to change(Source, :count).by(1)
+        end.to change(Source, :count).by(1)
       end
 
       it 'assigns a newly created source as @source' do
@@ -66,74 +67,74 @@ describe SourcesController do
       end
 
       it 'creates a source with a nested contributor' do
-        expect {
-          post :create, params: { source: { name: 'Data Source', partner_id: partner.id, partner_attributes: { name: 'Contributor' }} }
-        }.to change(Partner, :count).by(1)
+        expect do
+          post :create, params: { source: { source_id: 'Data Source', partner_id: partner.id, partner_attributes: { name: 'Contributor' }} }
+        end.to change(Partner, :count).by(1)
       end
     end
 
-    describe "with invalid params" do
-      it "assigns a newly created but unsaved source as @source" do
-        post :create, params: { source: { name: '' }}
+    describe 'with invalid params' do
+      it 'assigns a newly created but unsaved source as @source' do
+        post :create, params: { source: { source_id: '' }}
         expect(assigns(:source)).to be_a_new(Source)
       end
 
       it "re-renders the 'new' template" do
-        post :create, params: { source: { name: '' } }
+        post :create, params: { source: { source_id: '' } }
         expect(response).to render_template('new')
       end
     end
   end
 
   describe 'PUT update' do
-    before(:each) {
+    before(:each) do
       allow(controller).to receive(:current_user) { build(:user, role: 'admin') }
-    }
+    end
 
     describe 'with valid params' do
       it 'updates the requested source' do
         source = Source.create! valid_attributes
-        put :update, params: { id: source.to_param, source: { name: 'updated' }}
+        put :update, params: { id: source.to_param, source: { source_id: 'updated' }}
 
-        expect(source.reload.name).to eq 'updated'
+        expect(source.reload.source_id).to eq 'updated'
       end
 
-      it "assigns the requested source as @source" do
+      it 'assigns the requested source as @source' do
         source = Source.create! valid_attributes
         put :update, params: { id: source.to_param, source: valid_attributes }
         expect(assigns(:source)).to eq(source)
       end
 
-      it "redirects to the sources index" do
+      it 'redirects to the sources index' do
         source = Source.create! valid_attributes
         put :update, params: { id: source.to_param, source: valid_attributes }
         expect(response).to redirect_to sources_path
       end
     end
 
-    describe "with invalid params" do
-      it "assigns the source as @source" do
+    describe 'with invalid params' do
+      it 'assigns the source as @source' do
         source = Source.create! valid_attributes
-        put :update, params: { id: source.to_param, source: { name: '' } }
+        put :update, params: { id: source.to_param, source: { source_id: '' } }
         expect(assigns(:source)).to eq(source)
       end
 
       it "re-renders the 'edit' template" do
         source = Source.create! valid_attributes
-        put :update, params: { id: source.to_param, source: { name: '' }}
+        put :update, params: { id: source.to_param, source: { source_id: '' } }
         expect(response).to render_template('edit')
       end
     end
 
-    describe "GET reindex" do
-      before(:each) {
+    describe 'GET reindex' do
+      before(:each) do
         allow(controller).to receive(:current_user) { build(:user, role: 'admin') }
-      }
+      end
 
-      it "calls reindex on api" do
+      it 'calls reindex on api' do
         source = Source.create! valid_attributes
         expect(RestClient).to receive(:get).with("#{ENV['API_HOST']}/harvester/sources/#{source.id}/reindex", params: { date: '2013-09-12T01:49:51.067Z', api_key: ENV['HARVESTER_API_KEY'] })
-        get :reindex,  params: { id: source.to_param, env: 'test', date: "2013-09-12T01:49:51.067Z", format: :js }
+        get :reindex, params: { id: source.to_param, env: 'test', date: '2013-09-12T01:49:51.067Z', format: :js }
       end
     end
   end

--- a/spec/factories/sources.rb
+++ b/spec/factories/sources.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :source do
-    sequence(:name) {|n| "A Source #{n}" }
     sequence(:source_id) {|n| "source_#{n}"}
     partner { build(:partner) }
   end

--- a/spec/features/parsers/manage_parser_scripts_spec.rb
+++ b/spec/features/parsers/manage_parser_scripts_spec.rb
@@ -23,15 +23,15 @@ feature 'Manage parser', type: :feature, js: true do
   end
 
   scenario 'Only list sources within the selected partner' do
-    partner = create(:source, name: 'Source to be listed').partner
-    orphan_source = create(:source, name: 'Source not to be listed')
+    partner = create(:source, source_id: 'Source to be listed').partner
+    orphan_source = create(:source, source_id: 'Source not to be listed')
     parser_form_page = ParserFormPage.new
 
     click_link 'New Parser Script'
     select partner.name
 
-    expect(parser_form_page.parser_source_dropdown).to have_content(partner.sources.first.name)
-    expect(parser_form_page.parser_source_dropdown).not_to have_content(orphan_source.name)
+    expect(parser_form_page.parser_source_dropdown).to have_content(partner.sources.first.source_id)
+    expect(parser_form_page.parser_source_dropdown).not_to have_content(orphan_source.source_id)
   end
 
   context 'Create a new parser script' do
@@ -44,7 +44,7 @@ feature 'Manage parser', type: :feature, js: true do
 
       fill_in 'parser[name]', with: new_parser.name
       select partner.name
-      select partner.sources.first.name
+      select partner.sources.first.source_id
     end
 
     scenario 'valid JSON parser' do

--- a/spec/features/sources/manage_sources_spec.rb
+++ b/spec/features/sources/manage_sources_spec.rb
@@ -18,7 +18,7 @@ feature 'Manage sources', type: :feature, js: true do
 
   scenario 'See all sources' do
     sources.each do |source|
-      expect(all_sources_page.source_table).to have_content(source.name)
+      expect(all_sources_page.source_table).to have_content(source.source_id)
     end
   end
 
@@ -28,26 +28,28 @@ feature 'Manage sources', type: :feature, js: true do
 
       click_link 'New Data Source'
 
-      fill_in 'source[name]', with: new_source.name
+      fill_in 'source[source_id]', with: new_source.source_id
       select sources.first.partner.name
 
       click_button 'Create Data Source'
 
       sources.each do |source|
-        expect(all_sources_page.source_table).to have_content(source.name)
+        expect(all_sources_page.source_table).to have_content(source.source_id)
       end
-      expect(all_sources_page.source_table).to have_content(new_source.name)
+      expect(all_sources_page.source_table).to have_content(new_source.source_id)
     end
   end
 
   scenario 'Update a source' do
-    click_link sources.first.name
+    new_partner = create(:partner)
 
-    fill_in 'source[name]', with: 'Updated name!!'
+    click_link sources.first.source_id
+
+    select new_partner.name
 
     click_button 'Update Data Source'
 
-    expect(all_sources_page.source_table).to have_content('Updated name!!')
+    expect(all_sources_page.source_table).to have_content(new_partner.name)
     expect(all_sources_page).to have_flash_success
   end
 end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -47,8 +47,8 @@ describe Source do
       source.save
     end
 
-    it 'calls slugfy_source_id' do
-      expect(source).to receive(:slugfy_source_id)
+    it 'calls slugify_source_id' do
+      expect(source).to receive(:slugify_source_id)
       source.save
     end
   end
@@ -68,7 +68,7 @@ describe Source do
     end
   end
 
-  describe '#slugfy_source_id' do
+  describe '#slugify_source_id' do
     it 'removes excess whitespace and replaces them with underscores in the source_id' do
       source.source_id = 'Source     4'
       source.save!
@@ -85,7 +85,7 @@ describe Source do
   describe 'creating a new source' do
     let(:new_source) { Source.new(source_id: 'New source', partner: create(:partner)) }
 
-    it 'creates a new source slugfying the source_id with #slugfy_source_id' do
+    it 'creates a new source slugifying the source_id with #slugfy_source_id' do
       new_source.save!
       expect(new_source.source_id).to eq 'new_source'
     end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require 'rails_helper'
 
@@ -10,53 +11,50 @@ describe Source do
     allow(LinkCheckRule).to receive(:create)
   end
 
-  describe "validations" do
-    it "is valid with valid attributes" do
+  describe 'validations' do
+    it 'is valid with valid attributes' do
       expect(source.valid?).to be true
     end
 
-    it "is not valid without a name" do
-      s = build(:source, name: nil)
-      expect(s.valid?).to be false
-    end
-
-    it "is not valid without a source_id" do
+    it 'is not valid without a source_id' do
       s = build(:source, source_id: nil)
-      # create_source_id is called before validation so if it is
-      # not stubbed then the source id will be set.
-      allow(s).to receive(:create_source_id)
       expect(s.valid?).to be false
     end
 
-    it "must have a partner" do
+    it 'must have a partner' do
       s = build(:source, partner_id: nil)
       expect(s.valid?).to be false
     end
 
-    it "must have a unique source_id" do
-      s1 = create(:source, source_id: 'test')
+    it 'must have a unique source_id' do
+      create(:source, source_id: 'test')
       s2 = build(:source, source_id: 'test')
 
       expect(s2.valid?).to be false
     end
   end
 
-  describe "after create" do
-    it "calls create_link_check_rule" do
+  describe 'after create' do
+    it 'calls create_link_check_rule' do
       expect(source).to receive(:create_link_check_rule)
       source.save
     end
   end
 
-  describe "after save" do
-    it "calls update_apis" do
+  describe 'after save' do
+    it 'calls update_apis' do
       expect(source).to receive(:update_apis)
+      source.save
+    end
+
+    it 'calls slugfy_source_id' do
+      expect(source).to receive(:slugfy_source_id)
       source.save
     end
   end
 
-  describe "#create_link_check_rule" do
-    it "should create the rule in each backend_environment" do
+  describe '#create_link_check_rule' do
+    it 'should create the rule in each backend_environment' do
       APPLICATION_ENVS.each do |env|
         expect(source).to receive(:set_worker_environment_for).with(LinkCheckRule, env)
         expect(LinkCheckRule).to receive(:create)
@@ -64,40 +62,32 @@ describe Source do
       source.send(:create_link_check_rule)
     end
 
-    it "should create an inactive LinkCheckRule" do
+    it 'should create an inactive LinkCheckRule' do
       expect(LinkCheckRule).to receive(:create).with(source_id: source.id, active: false)
       source.send(:create_link_check_rule)
     end
   end
 
-  describe "#create_source_id" do
-    context "a source with a source_id" do
-      it "doesn't create a source_id if one exists" do
-        current_source_id = source.source_id
-        source.send(:create_source_id)
-        expect(source.source_id).to eq current_source_id
-      end
+  describe '#slugfy_source_id' do
+    it 'removes excess whitespace and replaces them with underscores in the source_id' do
+      source.source_id = 'Source     4'
+      source.save!
+      expect(source.source_id).to eq 'source_4'
     end
 
-    context "creating a new source" do
-      let(:new_source) { Source.new(name: "New source", partner: 123) }
+    it 'only includes alphanumeric characters in the source_id' do
+      source.source_id = '@84 $ource!!'
+      source.save!
+      expect(source.source_id).to eq '84_ource'
+    end
+  end
 
-      it "creates a new source_id using the name" do
-        new_source.send(:create_source_id)
-        expect(new_source.source_id).to eq "new_source"
-      end
+  describe 'creating a new source' do
+    let(:new_source) { Source.new(source_id: 'New source', partner: create(:partner)) }
 
-      it "removes excess whitespace and replaces them with underscores in the source_id" do
-        new_source.name = "New      Source     4"
-        new_source.send(:create_source_id)
-        expect(new_source.source_id).to eq "new_source_4"
-      end
-
-      it "only includes alphanumeric characters in the source_id" do
-        new_source.name = "@New 84 $ource!!"
-        new_source.send(:create_source_id)
-        expect(new_source.source_id).to eq "new_84_ource"
-      end
+    it 'creates a new source slugfying the source_id with #slugfy_source_id' do
+      new_source.save!
+      expect(new_source.source_id).to eq 'new_source'
     end
   end
 end

--- a/spec/serializers/source_serializer_spec.rb
+++ b/spec/serializers/source_serializer_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe SourceSerializer do
       expect(serializer).to have_key(:id)
     end
 
-    it 'has a name' do
-      expect(serializer).to have_key(:name)
-    end
-
     it 'has a source_id' do
       expect(serializer).to have_key(:source_id)
     end


### PR DESCRIPTION
**Acceptance Criteria**
- Source Names are completely removed from SJ (front and back end)
- Source ID is used directly in all cases where Source Name previously was