### PR TITLE
SJ JOB DETAILS PAGE BUG: As Ting, I dont want harvest errors to break the job details page, so that I am able to see what the harvest errors are and fix them

### DIFF
--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -158,7 +158,7 @@
             <% if Nokogiri::XML(record.raw_data).errors.empty? %>
               <%= text_area_tag "", Nokogiri::XML(record.raw_data), class: 'code-editor-multiple read-only', data: { mode: 'application/xml'} %>
             <% else %>
-              <%= text_area_tag "", record.raw_data), class: 'code-editor-multiple read-only', data: { mode: 'text/x-ruby' } %>
+              <%= text_area_tag "", record.raw_data, class: 'code-editor-multiple read-only', data: { mode: 'text/x-ruby' } %>
             <% end %>
           <% end %>
 

--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -158,7 +158,7 @@
             <% if Nokogiri::XML(record.raw_data).errors.empty? %>
               <%= text_area_tag "", Nokogiri::XML(record.raw_data), class: 'code-editor-multiple read-only', data: { mode: 'application/xml'} %>
             <% else %>
-              <%= text_area_tag "", JSON.pretty_generate(JSON.parse(record.raw_data)), class: 'code-editor-multiple read-only', data: { mode: 'text/x-ruby' } %>
+              <%= text_area_tag "", record.raw_data), class: 'code-editor-multiple read-only', data: { mode: 'text/x-ruby' } %>
             <% end %>
           <% end %>
 
@@ -186,7 +186,7 @@
             <% if Nokogiri::XML(record.raw_data).errors.empty? %>
               <%= text_area_tag "", Nokogiri::XML(record.raw_data), class: 'code-editor-multiple read-only', data: { mode: 'application/xml'} %>
             <% else %>
-              <%= text_area_tag "", JSON.pretty_generate(JSON.parse(record.raw_data)), class: 'code-editor-multiple read-only', data: { mode: 'text/x-ruby' } %>
+              <%= text_area_tag "", record.raw_data, class: 'code-editor-multiple read-only', data: { mode: 'text/x-ruby' } %>
             <% end %>
           <% end %>
 


### PR DESCRIPTION
Error was caused by JSON parsing a string. I have looked in the data that we have on production and the data is not JSON so it makes sense that this would error. 