### PR TITLE
IMPROVE SJ PARSERS PAGE

### DIFF
--- a/app/assets/javascripts/parsers.js
+++ b/app/assets/javascripts/parsers.js
@@ -96,8 +96,40 @@ $(function() {
     }
   });
 
+
+
   return $('#parsers').dataTable({
-    "aaSorting": [[4, 'desc']]
+    "processing": true,
+    "serverSide": true,
+    "ajax": "/parsers/datatable",
+    "aaSorting": [[4, 'desc']],
+    "columns": [
+      {
+        "data": "name",
+        "render": function(data, type, row, meta) {
+          return `<a href="/parsers/${row.id}/edit">${data}</a>`;
+        }
+      },
+      { "data": "strategy" },
+      {
+        "data": "partner_name",
+        "render": function(data, type, row, meta) {
+          debugger;
+          if (!row.can_update) return row.partner_name;
+          return `<a href="/partners/${row.partner.id}/edit">${row.partner.name}</a>`;
+        }
+      },
+      {
+        "data": "source_name",
+        "render": function(data, type, row, meta) {
+          if (!row.can_update) return row.source.name;
+          return `<a href="/sources/${row.source.id}/edit">${row.source.name}</a>`;
+        }
+      },
+      { "data": "updated_at" },
+      { "data": "last_editor" },
+      { "data": "data_type" },
+    ]
   });
 });
 

--- a/app/assets/javascripts/parsers.js
+++ b/app/assets/javascripts/parsers.js
@@ -114,7 +114,6 @@ $(function() {
       {
         "data": "partner_name",
         "render": function(data, type, row, meta) {
-          debugger;
           if (!row.can_update) return row.partner_name;
           return `<a href="/partners/${row.partner.id}/edit">${row.partner.name}</a>`;
         }

--- a/app/controllers/parsers_controller.rb
+++ b/app/controllers/parsers_controller.rb
@@ -102,11 +102,12 @@ class ParsersController < ApplicationController
   end
 
   def datatable_params
+    sorted_by_column = params[:order]['0'][:column]
     {
       search:    params[:search][:value],
       start:     params[:start].to_i,
       per_page:  params[:length].to_i,
-      order_by:  params[:columns][params[:order]['0'][:column]][:data],
+      order_by:  params[:columns][sorted_by_column][:data],
       direction: params[:order]['0'][:dir],
     }
   end

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -223,7 +223,6 @@ class Parser
     self.partner_name = source&.partner.name
   end
 
-
   def update_source_name
     self.source_name = source&.source_id
   end

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -13,7 +13,12 @@ class Parser
   field :content,   type: String
   field :data_type, type: String, default: "record"
   field :allow_full_and_flush, type: Boolean, default: true
-  field :last_editor, type: String
+
+  # Used for the /parsers page which includes these 3 fields
+  # As MongoDB doesn't allow to sort and search accross collections
+  field :last_editor,  type: String
+  field :partner_name, type: String
+  field :source_name,  type: String
 
   index(name: 1) # requires this index as parsers are sorted with name in controller
 
@@ -40,6 +45,8 @@ class Parser
   before_destroy { |parser| HarvestSchedule.destroy_all_for_parser(parser.id) }
 
   before_save :update_last_editor
+  before_save :update_partner_name
+  before_save :update_source_name
 
   def parser_name_is_a_valid_class_name
     errors.add(:name, 'Your Parser Name includes invalid characters. Please remove the /.') if name.include? '/'
@@ -48,6 +55,33 @@ class Parser
     if e.message.include? 'wrong constant name'
       errors.add(:name, 'Parser name includes invalid characters. The name can only contain Alphabetical or Numeric characters, and can not start with a number.')
     end
+  end
+
+  def self.datatable_query(params)
+    Parser
+      .offset(params[:start])
+      .limit(params[:per_page])
+      .order_by(params[:order_by] => params[:direction])
+      .includes(:source)
+      .only(
+        :name,
+        :strategy,
+        :source,
+        :data_type,
+        :updated_at,
+        :last_editor,
+        :source_name,
+        :partner_name
+      ).where(
+        '$or' => [
+          { name:         /#{params[:search]}/i },
+          { stragegy:     /#{params[:search]}/i },
+          { data_type:    /#{params[:search]}/i },
+          { last_editor:  /#{params[:search]}/i },
+          { partner_name: /#{params[:search]}/i },
+          { source_name:  /#{params[:search]}/i },
+        ]
+      )
   end
 
   def self.find_by_partners(partner_ids=[])
@@ -181,9 +215,16 @@ class Parser
     allow_full_and_flush
   end
 
-  # This is for performance reasons.
-  # Loading versions.last on the /parsers page is very slow
   def update_last_editor
     self.last_editor = last_edited_by
+  end
+
+  def update_partner_name
+    self.partner_name = source&.partner.name
+  end
+
+
+  def update_source_name
+    self.source_name = source&.source_id
   end
 end

--- a/app/models/presenters/datatable_parsers.rb
+++ b/app/models/presenters/datatable_parsers.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Presenters
+  class DatatableParsers
+    def initialize(parsers, can_update)
+      @parsers = parsers
+      @can_update = can_update
+    end
+
+    def call
+      @parsers.map do |parser|
+        {
+          id: parser.id,
+          name: parser.name,
+          strategy: parser.strategy,
+          updated_at: parser&.updated_at&.localtime&.to_formatted_s(:long),
+          last_editor: parser.last_editor,
+          data_type: parser.data_type,
+          source: {
+            id: parser.source_id,
+            name: parser&.source_name
+          },
+          partner: {
+            id: parser.source.partner.id,
+            name: parser.partner_name,
+          },
+          can_update: @can_update
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/parser_serializer.rb
+++ b/app/serializers/parser_serializer.rb
@@ -1,6 +1,6 @@
 
 class ParserSerializer < ActiveModel::Serializer
-  
+
   attributes :id, :name, :strategy, :content, :file_name, :source, :data_type, :allow_full_and_flush
 
 end

--- a/app/views/parsers/index.html.erb
+++ b/app/views/parsers/index.html.erb
@@ -10,35 +10,9 @@
       <th>Data Format</th>
       <th>Partner</th>
       <th>Source ID</th>
-      <th>Last Updated</th>
+      <th>Last Update</th>
       <th>Last Edited By</th>
       <th>Parser Type</th>
     </tr>
   </thead>
-
-  <tbody>
-    <% @parsers.try(:each) do |parser| %>
-      <% if can? :update, parser %>
-        <tr>
-          <td><%= link_to parser.name, edit_parser_path(parser) %></td>
-          <td><%= parser.strategy %></td>
-          <td><%= link_to parser.source.partner.name, edit_partner_path(parser.source.partner) %></td>
-          <td><%= link_to parser.source.source_id, edit_source_path(parser.source) %></td>
-          <td><%= parser.try(:updated_at).try(:localtime)&.to_formatted_s(:long) %></td>
-          <td><%= parser.last_editor %></td>
-          <td><%= parser.data_type %></td>
-        </tr>
-      <% else %>
-        <tr>
-          <td><%= link_to parser.name, parser_path(parser) %></td>
-          <td><%= parser.strategy %></td>
-          <td><%= parser.source.partner.name %></td>
-          <td><%= parser.source.source_id %></td>
-          <td><%= parser.try(:updated_at).try(:localtime)&.to_formatted_s(:long) %></td>
-          <td><%= parser.last_editor %></td>
-          <td><%= parser.data_type %></td>
-        </tr>
-      <% end %>
-    <% end %>
-  </tbody>
 </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ HarvesterManager::Application.routes.draw do
 
   resources :parsers do
     get :allow_flush, on: :member
-    collection { get 'datatable', constraints: { format: :json } }
+    get 'datatable', on: :collection, constraints: { format: :json }
     resources :previewers, only: [:create]
     resources :parser_versions, path: 'versions', only: [:show, :update] do
       get :current, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ HarvesterManager::Application.routes.draw do
 
   resources :parsers do
     get :allow_flush, on: :member
+    collection { get 'datatable', constraints: { format: :json } }
     resources :previewers, only: [:create]
     resources :parser_versions, path: 'versions', only: [:show, :update] do
       get :current, on: :collection

--- a/spec/controllers/parsers_controller_spec.rb
+++ b/spec/controllers/parsers_controller_spec.rb
@@ -19,13 +19,48 @@ describe ParsersController do
   end
 
   describe "GET 'index'" do
-    it 'finds all the parser configurations' do
+    it 'returns a 200 status code' do
       get :index
-      expect(assigns(:parsers)).to eq [parser]
+      expect(response).to have_http_status(200)
     end
   end
 
-  describe 'GET show' do
+  describe "GET 'datatable'" do
+    before do
+      # GET parameters from datatable are too complex
+      # so it is stubbed
+      allow_any_instance_of(ParsersController).to receive(:datatable_params).and_return({
+              search:    '',
+              start:     0,
+              per_page:  20,
+              order_by:  'updated_at',
+              direction: 'desc'
+            })
+    end
+
+    it 'returns a 200 status code' do
+      get :datatable
+      expect(response).to have_http_status(200)
+    end
+
+    it 'returns JSON' do
+      get :datatable
+      expect(response.header['Content-Type']).to include 'application/json'
+    end
+
+    it 'returns an array of parsers' do
+      get :datatable
+      JSON.parse(response.body)['data'].each do |parser|
+        expect(parser).to include(
+          * %w[id name strategy updated_at last_editor data_type source partner can_update]
+        )
+        expect(parser['source']).to include(* %w[id name])
+        expect(parser['partner']).to include(* %w[id name])
+      end
+    end
+  end
+
+  describe "GET 'show'" do
     it 'finds an existing parser' do
       expect(Parser).to receive(:find).with('1234') { parser }
       get :show, params: { id: '1234' }

--- a/spec/models/parser_spec.rb
+++ b/spec/models/parser_spec.rb
@@ -264,4 +264,44 @@ describe Parser do
       expect(parser.last_editor).to eq 'John Doe'
     end
   end
+
+  describe '#datatable_query' do
+    let(:user)    { create(:user) }
+    let(:version) { build(:version, :staging, user: user) }
+    let(:parser)  { create(:parser) }
+    let(:options) { {
+      search:    '',
+      start:     5,
+      per_page:  20,
+      order_by:  'updated_at',
+      direction: 'desc'
+    } }
+
+    it 'returns a MongoID::Criteria' do
+      expect(Parser.datatable_query(options)).to be_a(Mongoid::Criteria)
+    end
+
+    it 'returns a limited number of records' do
+      query = Parser.datatable_query(options)
+      expect(query.options[:limit]).to eq(20)
+    end
+
+    it 'returns parsers with the offset given' do
+      query = Parser.datatable_query(options)
+      expect(query.options[:skip]).to eq(5)
+    end
+
+    it 'returns only the needed fields' do
+      query = Parser.datatable_query(options)
+      expect(query.options[:fields]).to include(*%w[
+        _id name strategy source_id data_type
+        updated_at last_editor source_name partner_name
+      ])
+    end
+
+    it 'orders by the given field' do
+      query = Parser.datatable_query(options)
+      expect(query.options[:sort]).to eq({'updated_at' => -1})
+    end
+  end
 end


### PR DESCRIPTION
Acceptance Criteria
===================

**Acceptance Criteria**
- Parsers page load time is drastically improved (from 16+ seconds)
https://manager.digitalnz.org/parsers 
- Latest 20 parsers and Search box functionality remains

**Notes**
- Paul has done some investigation in this story
https://basecamp.com/1723294/projects/8491945/messages/86419195
- A huge page listing ALL parsers is not really useful at all.
The search button and the latest 20 is all we really use.


Background
==========

- Remove the `<table>` body as datatable will generate it with a AJAX request
- Add an endpoint `/parsers/datatable` for datatable to get the actual data
- Create a method `datatable_query`
- Write some model and controller
- Feature testing doesn't change as the UI stays the same

Checklist
=========

- [ ] Code is understandable without Dev
- [ ] Acceptance criteria, what was changed, and why it was changed (If applicable) on Pull / Merge Request
- [ ] Code Coverage goes up
- [ ] All new methods have a relevant spec
- [ ] Methods have a single responsibility (Where applicable)
- [ ] Builds Pass
- [ ] ‘Yard’ style comments on methods and classes (Where applicable)
