### PR TITLE
DELETED PARSER BREAKING JOBS PAGE: As Dan, I want parsers to be cleanly soft deleted, so that the rest of SJ does not get confused by missing parsers

### DIFF
--- a/app/models/abstract_job.rb
+++ b/app/models/abstract_job.rb
@@ -64,6 +64,8 @@ class AbstractJob < ActiveResource::Base
   # along with the AbstractJob details
   def parser_name
     Parser.only(:name).find(parser_id).name
+  rescue Mongoid::Errors::DocumentNotFound
+    ''
   end
 
   def user

--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -1,13 +1,13 @@
-
-
 <%= content_tag :div, id: "harvest-job", data: { url: harvest_job_path(@harvest_job, format: "js"), active: !@harvest_job.finished? } do %>
 
   <h2 class="left">
     <%= t("harvest_jobs.progress") %>
-    <% if can? :update, @harvest_job.parser %>
-      <span class="parser-title">: <%= link_to @harvest_job.parser.try(:name), edit_parser_path(@harvest_job.parser) %></span>
-    <% else %>
-      <span class="parser-title">: <%= @harvest_job.parser.try(:name) %></span>
+    <% if @harvest_job.parser.present? %>
+      <% if can? :update, @harvest_job.parser %>
+        <span class="parser-title">: <%= link_to @harvest_job.parser.try(:name), edit_parser_path(@harvest_job.parser) %></span>
+      <% else %>
+        <span class="parser-title">: <%= @harvest_job.parser.try(:name) %></span>
+      <% end %>
     <% end %>
   </h2>
 


### PR DESCRIPTION
Job activity still loads even when the parser is gone. 