### PR TITLE
FIX THE MANAGER CONFIGURATION: Part 5. Display form errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,52 @@
-FROM ruby:2.6.5-alpine AS builder
+FROM ruby:2.6.5
 
-# install packages
-ARG RAILS_ENV='production'
-ARG BUILD_PACKAGES='build-base curl-dev git'
-ARG DEV_PACKAGES='yaml-dev zlib-dev nodejs yarn'
-ARG RUBY_PACKAGES='tzdata'
-RUN apk add --no-cache $BUILD_PACKAGES $DEV_PACKAGES $RUBY_PACKAGES
+RUN apt-get update -qq && apt-get install -y \
+    build-essential \
+    openssh-client \
+    libpq-dev \
+    apt-transport-https \
+    libxml2-dev \
+    libxslt1-dev \
+    libxslt-dev \
+    liblzma-dev \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
 
-# install rubygem
-WORKDIR /app
-RUN bundle config set without 'development:test'
-COPY Gemfile Gemfile.lock ./
-RUN gem install bundler -v $(tail -n1 Gemfile.lock) \
-    && bundle config --global frozen 1 \
-    && bundle install --jobs=4 --retry=3 \
-    # Remove unneeded files (cached *.gem, *.o, *.c)
-    && rm -rf $GEM_HOME/cache/*.gem \
-    && find $GEM_HOME/gems/ -name '*.c' -delete \
-    && find $GEM_HOME/gems/ -name '*.o' -delete
+# Add yarn to the packages list
+RUN curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-# compile assets
+# Add node to the packages list
+RUN curl -sSL https://deb.nodesource.com/setup_12.x | bash -
+
+# Install external packages
+RUN apt-get update -qq && apt-get install -y \
+    yarn \
+    nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG RAILS_ENV
+ENV RAILS_ENV=$RAILS_ENV
+
+ARG TIMEZONE
+ENV TIMEZONE=$TIMEZONE
+
+RUN echo $TIMEZONE > /etc/timezone
+RUN dpkg-reconfigure -f noninteractive tzdata
+
+RUN mkdir -p /var/tmp
+WORKDIR /var/tmp
+COPY Gemfile .
+COPY Gemfile.lock .
+RUN gem install bundler
+RUN NOKOGIRI_USE_SYSTEM_LIBRARIES=1 bundle install
+
+RUN mkdir -p /var/manager
+WORKDIR /var/manager
 COPY . .
-RUN cp config/application.yml.docker config/application.yml
-ARG RAILS_ENV='production'
-ENV RAILS_ENV=$RAILS_ENV
-RUN bundle exec rails assets:precompile
 
-# Remove folders not needed in resulting image
-RUN rm -rf tmp/cache vendor/assets spec package.json yarn.lock
-
-############### Build step done ###############
-
-FROM ruby:2.6.5-alpine
-
-# install packages
-ARG PACKAGES='tzdata nodejs ncurses'
-RUN apk add --no-cache $PACKAGES
-
-# copy files from builder
-WORKDIR /app
-COPY --from=builder $GEM_HOME $GEM_HOME
-COPY --from=builder /app /app
-
-# set environment variables
-ARG RAILS_ENV='production'
-ENV RAILS_ENV=$RAILS_ENV
-ARG TZ='Pacific/Auckland'
-ENV TZ=$TZ
+RUN mv config/application.yml.docker config/application.yml
+RUN RAILS_ENV=$RAILS_ENV bundle exec rails assets:precompile
 
 EXPOSE 3000
 

--- a/app/assets/javascripts/parsers.js
+++ b/app/assets/javascripts/parsers.js
@@ -85,14 +85,14 @@ $(function() {
     return $(this).hide();
   });
 
-  stored_sources = $('#parser_source_id optgroup');
-  $('#parser_partner').change(function() {
+  stored_sources = $('select[name="parser[source_id]"] optgroup');
+  $('select[name="parser[partner]"]').change(function() {
     var partner;
-    partner = $('#parser_partner').val();
-    $('#parser_source_id optgroup').remove();
-    $('#parser_source_id').append(stored_sources);
+    partner = $('select[name="parser[partner]"]').val();
+    $('select[name="parser[source_id]"] optgroup').remove();
+    $('select[name="parser[source_id]"]').append(stored_sources);
     if (partner !== "") {
-      return $("#parser_source_id optgroup[label!='" + partner + "']").remove();
+      return $("select[name=\"parser[source_id]\"] optgroup[label!='" + partner + "']").remove();
     }
   });
 

--- a/app/assets/stylesheets/blocks/_forms.scss
+++ b/app/assets/stylesheets/blocks/_forms.scss
@@ -1,13 +1,37 @@
-.error {
-  small {
+.field_with_errors {
+  label {
     color: $alert-color;
-    display: block;
-    margin-bottom: 1rem;
+    font-weight: bold;
   }
 
-  input, select {
-    margin-bottom: .5rem;
+  [type="text"],
+  [type="password"],
+  [type="date"],
+  [type="datetime"],
+  [type="datetime-local"],
+  [type="month"],
+  [type="week"],
+  [type="email"],
+  [type="number"],
+  [type="search"],
+  [type="tel"],
+  [type="time"],
+  [type="url"],
+  [type="color"],
+  textarea,
+  select {
+    border-color: $alert-color;
   }
+}
+
+small.error {
+  display: block;
+  margin-top: -.5rem;
+  margin-bottom: 1rem;
+}
+
+.error {
+  color: $alert-color;
 }
 
 select {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,11 @@
 module ApplicationHelper
   include EnvironmentHelpers
 
+  def custom_form_with(model: nil, scope: nil, url: nil, format: nil, **options, &block)
+    options[:builder] = CustomFormBuilder
+    form_with model: model, scope: scope, url: url, format: format, **options, &block
+  end
+
   def display_base_errors(resource)
     return '' if (resource.errors.empty?) || (resource.errors[:base].empty?)
     messages = resource.errors[:base].map { |msg| content_tag(:p, msg) }.join

--- a/app/helpers/collection_statistics_helper.rb
+++ b/app/helpers/collection_statistics_helper.rb
@@ -9,6 +9,7 @@ module CollectionStatisticsHelper
       link_to '', environment_collection_statistic_path(params[:environment], (@day.to_date - 1.day).to_s), html_options
     end
   end
+
   def link_to_next_day(day, environment, html_options = {})
     if (@day.to_date + 1.day) > Date.today
       html_options[:class] << ' disabled'

--- a/app/helpers/custom_form_builder.rb
+++ b/app/helpers/custom_form_builder.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class CustomFormBuilder < ActionView::Helpers::FormBuilder
+  def error_wrapper(method, options, &block)
+    block.call + object.errors[method].uniq.map do |error_msg|
+      @template.content_tag(:small, error_msg, class: :error)
+    end.join.html_safe
+  end
+
+  %w[
+    text_field
+    text_area
+    password_field
+    search_field
+    telephone_field
+    date_field
+    datetime_local_field
+    month_field
+    week_field
+    url_field
+    email_field
+    color_field
+    time_field
+    number_field
+    range_field
+  ].each do |field_type|
+    define_method(field_type) do |method, options = {}|
+      error_wrapper(method, options) do
+        super(method, options)
+      end
+    end
+  end
+
+  def select(method, choices = nil, options = {}, html_options = {}, &block)
+    error_wrapper(method, options) do
+      super(method, choices, options, html_options, &block)
+    end
+  end
+
+  def grouped_collection_select(method, collection, group_method, group_label_method, option_key_method, option_value_method, options = {}, html_options = {})
+    error_wrapper(method, options) do
+      super(method, collection, group_method, group_label_method, option_key_method, option_value_method, options, html_options)
+    end
+  end
+end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module PartnersHelper
-end

--- a/app/helpers/previews_helper.rb
+++ b/app/helpers/previews_helper.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-module PreviewsHelper
-end

--- a/app/views/enrichment_jobs/_form.html.erb
+++ b/app/views/enrichment_jobs/_form.html.erb
@@ -22,8 +22,6 @@
       ) do |b|
         b.label { b.radio_button + b.text}
       end
-        # label: ,
-        # label_html: { class: 'large' }
     %>
   <% end %>
 

--- a/app/views/harvest_jobs/_form.html.erb
+++ b/app/views/harvest_jobs/_form.html.erb
@@ -6,7 +6,7 @@
 <% unless @parser.valid_parser?(@harvest_job.environment, @version) %>
   <%= render 'parsers/error', error: @parser.error %>
 <% end %>
-<%= form_with model: @harvest_job do |f| %>
+<%= custom_form_with model: @harvest_job do |f| %>
   <%= f.hidden_field :parser_id %>
   <%= f.hidden_field :version_id %>
   <%= f.hidden_field :user_id %>

--- a/app/views/harvest_schedules/_form.html.erb
+++ b/app/views/harvest_schedules/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @harvest_schedule, html: { class: "harvest_schedule" }, local: true do |f| %>
+<%= custom_form_with model: @harvest_schedule, html: { class: "harvest_schedule" }, local: true do |f| %>
 
   <%= f.label :parser_id, 'Parser Script' %>
   <%= f.select :parser_id, @parsers.map { |parser| [parser.name, parser.id] }, include_blank: true %>

--- a/app/views/harvest_schedules/_mode.html.erb
+++ b/app/views/harvest_schedules/_mode.html.erb
@@ -1,6 +1,6 @@
 <div id="mode">
   <% if harvest_schedule.parser.present? %>
-    <%= form_with model: harvest_schedule, local: true do |f| %>
+    <%= custom_form_with model: harvest_schedule, local: true do |f| %>
       <%= f.label :mode, class: :large %>
 
       <%= f.collection_radio_buttons :mode, harvest_schedule.parser.modes, :first, :second, checked: harvest_schedule.mode do |b| %>

--- a/app/views/link_check_rules/_form.html.erb
+++ b/app/views/link_check_rules/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @link_check_rule do |f| %>
+<%= custom_form_with model: @link_check_rule do |f| %>
   <%= f.label :source_id %>
   <%= f.grouped_collection_select(:source_id, Partner.all, :sources, :name, :id, :source_id) %>
 

--- a/app/views/parser_templates/edit.html.erb
+++ b/app/views/parser_templates/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="medium-9 cell">
     <h1 id="parser-template-title" class="float-left"><%= @parser_template.name %></h1>
     <div id="hidden-parser-template-form">
-      <%= form_with model: @parser_template, local: true do |f| %>
+      <%= custom_form_with model: @parser_template, local: true do |f| %>
         <div class="parser-template-form">
           <%= f.text_field :name %>
           <%= f.submit "Rename Parser template", class: 'button' %>
@@ -30,7 +30,7 @@
   </button>
 </div>
 
-<%= form_with model: @parser_template do |f| %>
+<%= custom_form_with model: @parser_template do |f| %>
   <%= f.text_area :content, class: "code-editor" %>
   <%= f.submit class: 'button' %>
 <% end %>

--- a/app/views/parser_templates/new.html.erb
+++ b/app/views/parser_templates/new.html.erb
@@ -4,9 +4,9 @@
   <%= t('parser_templates.helptext') %>
 </h5>
 
-<%= form_with model: @parser_template, local: true do |f| %>
-  <%= f.label :name, 'Parser Template Name' %>
-  <%= f.text_field :name, label: t('parser_templates.name')%>
+<%= custom_form_with model: @parser_template, local: true do |f| %>
+  <%= f.label :name, t('parser_templates.name') %>
+  <%= f.text_field :name %>
 
   <%= f.text_area :content, class: 'code-editor' %>
 

--- a/app/views/parser_templates/show.html.erb
+++ b/app/views/parser_templates/show.html.erb
@@ -4,6 +4,6 @@
 	</div>
 </div>
 
-<%= form_with model: @parser_template do |f| %>
+<%= custom_form_with model: @parser_template do |f| %>
   <%= f.text_field :content, class: "code-editor read-only" %>
 <% end %>

--- a/app/views/parsers/_form.html.erb
+++ b/app/views/parsers/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @parser, local: true do |f| %>
+<%= custom_form_with model: @parser, local: true do |f| %>
   <% if can? :update, @parser %>
     <%= f.text_field :content, label: false, class: "code-editor read" %>
 

--- a/app/views/parsers/_parser.html.erb
+++ b/app/views/parsers/_parser.html.erb
@@ -8,7 +8,7 @@
         </h1>
       <% end %>
       <div id="<%= 'hidden-parser-form' if @parser.errors.empty? %>">
-        <%= form_with model: @parser, local: true do |f| %>
+        <%= custom_form_with model: @parser, local: true do |f| %>
           <div class='parser-form'>
             <%= f.text_field :name %>
             <%= f.submit "Rename Parser", class: 'button' %>
@@ -161,7 +161,7 @@
 <div id="change-source-alert" class="reveal medium" data-reveal>
   <h2>Change source</h2>
   <p> Warning: changing the source of this parser does not affect records that have already been harvested.</p>
-  <%= form_with model: @parser do |f| %>
+  <%= custom_form_with model: @parser do |f| %>
     <%= f.label :partner, 'Contributor' %>
     <%= f.select :partner, Partner.all.sort(name: 1).map { |p| [p.name, p.name] }, selected: @parser.partner.name %>
     <%= f.label :source, 'Data source' %>

--- a/app/views/parsers/new.html.erb
+++ b/app/views/parsers/new.html.erb
@@ -5,15 +5,15 @@
     <%= t('parsers.new.helptext') %>
   </h5>
 
-  <%= form_with model: @parser, local: true do |f| %>
+  <%= custom_form_with model: @parser, local: true do |f| %>
     <%= f.label :name %>
     <%= f.text_field :name %>
 
     <%= f.label :partner %>
     <%= f.select :partner, @partners.map(&:name) %>
 
-    <%= f.label :source_id %>
-    <%= f.grouped_collection_select :source_id, @partners, :sources, :name, :id, :source_id, include_blank: true %>
+    <%= f.label :source %>
+    <%= f.grouped_collection_select :source, @partners, :sources, :name, :id, :source_id, {include_blank: true}, {name: 'parser[source_id]'} %>
 
     <%= f.label :strategy %>
     <%= f.select :strategy, Hash[Parser::VALID_STRATEGIES.map { |u| [(u == 'xml' ? "#{u}/html".upcase : u.upcase), u] }] %>

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @partner do |f| %>
+<%= custom_form_with model: @partner do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>
 

--- a/app/views/snippets/_form.html.erb
+++ b/app/views/snippets/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @snippet, local: true do |f| %>
+<%= custom_form_with model: @snippet, local: true do |f| %>
   <% if can? :update, @snippet %>
     <%= f.text_area :content, class: 'code-editor' %>
 

--- a/app/views/snippets/_snippet.html.erb
+++ b/app/views/snippets/_snippet.html.erb
@@ -3,7 +3,7 @@
     <h1 id="snippet-title" class="float-left"><%= @snippet.name %></h1>
     <% if can? :update, @snippet %>
       <div id="hidden-snippet-form">
-        <%= form_with model: @snippet, local: true do |f| %>
+        <%= custom_form_with model: @snippet, local: true do |f| %>
           <div class="snippet-form">
             <%= f.label :name %>
             <%= f.text_field :name %>

--- a/app/views/snippets/new.html.erb
+++ b/app/views/snippets/new.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t('snippets.create_a') %></h2>
 
-<%= form_with model: @snippet, local: true do |f| %>
+<%= custom_form_with model: @snippet, local: true do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>
 

--- a/app/views/sources/_form.html.erb
+++ b/app/views/sources/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @source, local: true do |f| %>
+<%= custom_form_with model: @source, local: true do |f| %>
 
   <% if @source.errors.any? %>
     <%= t('forms.error_notification.default_message') %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @user, local: true do |f| %>
+<%= custom_form_with model: @user, local: true do |f| %>
   <%= f.label :name %>
   <%= f.text_field :name %>
 

--- a/spec/page_objects/parser/parser_form_page.rb
+++ b/spec/page_objects/parser/parser_form_page.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class ParserFormPage < ApplicationPage
-  element :parser_source_dropdown, '#parser_source_id'
+  element :parser_source_dropdown, 'select[name="parser[source_id]"]'
 end


### PR DESCRIPTION
Acceptance Criteria
===================

**Acceptance Criteria**
- bundler-audit is not returning any vulnerabilities
- `simple_form` is removed
- `mongoid` is upgraded to version 7 for consistency with other projects
- rails is upgraded to version 5.2.4
- GitHub gems forks are avoided when possible
- `therubyracer` is removed

**Notes**
- VCR and webmock are installed but not used
- capybara has an old version
- This is story was broken off from https://www.pivotaltracker.com/story/show/169468440

Background
==========

- Created a custom form builder inheriting the `ActionView::Helpers::FormBuilder` to handle the error display properly
- Converted all `form_with` calls to `custom_form_with` to use it.