### PR TITLE
REMOVE CLEAR SECRET KEY BASE IN MANAGER: As Dan, I want the secret key base to be removed from the source code, so that network sniffers are not able to decrypt user cookies and take over their sessions

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -2,6 +2,14 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # the secret key base is set in config/initializers/secret_key_base
+  # config.secret_key = '9acf6acbf06ca46866a898eafd73fbd12b3848784f90336900220103b699de585a6fa58db6753716c4f4795d123f6b723661583b90f9af23c98eea0c94a24932'
+
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
@@ -16,8 +24,6 @@ Devise.setup do |config|
   # available as additional gems.
   # require 'devise/orm/active_record'
   require 'devise/orm/mongoid'
-
-  config.secret_key = ENV['SECRET_TOKEN'] || '9c3973a3344d174711d9f434f55d82e99322c23b8faf56b97b30bec9d3fc3bd34bfd01119c981d96daba24e63e69ad2f28785baad403caf613d671891523e745'
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is

--- a/config/initializers/secret_key_base.rb
+++ b/config/initializers/secret_key_base.rb
@@ -5,4 +5,7 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-HarvesterManager::Application.config.secret_key_base = ENV['SECRET_TOKEN'] || 'dae5a2dae24885a2d61248da5a61dae242e24885a2d885a4885a2d61d24885a2d61dad6185a2d61'
+Rails.application.config.secret_key_base = ENV.fetch(
+  'SECRET_KEY_BASE',
+  SecureRandom.hex(64)
+)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,9 +1,9 @@
 
 # Be sure to restart your server when you modify this file.
 
-HarvesterManager::Application.config.session_store :cookie_store, key: '_harvester_manager_session'
+Rails.application.config.session_store :cookie_store, key: '_harvester_manager_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information
 # (create the session table with "rails generate session_migration")
-# HarvesterManager::Application.config.session_store :active_record_store
+# Rails.application.config.session_store :active_record_store

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -31,7 +31,7 @@ workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-preload_app!
+# preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
[REMOVE CLEAR SECRET KEY BASE IN MANAGER: As Dan, I want the secret key base to be removed from the source code, so that network sniffers are not able to decrypt user cookies and take over their sessions](https://www.pivotaltracker.com/story/show/171917612)

STORY
=====

**Acceptance Criteria**
- the secret key base is removed from the source code
- the secret key base is changed
- users trying to connect do not get an error

WHAT WAS DONE
==============

- Removed the default secret key base and used a random generator in case the environment variable is not set
- Related PR: https://gitlab.digitalnz.org/digitalnz/dnz-kubernetes/-/merge_requests/369