### PR TITLE
SJ - PREVENT EMPTY PARSER VERSION NAME: As Allister I want version names/messages to be validated, so that empty names are not allowed

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -16,8 +16,6 @@ class Version
   embedded_in :versionable, polymorphic: true
   delegate :name, :strategy, :file_name, to: :versionable
 
-  validates :message, presence: true
-
   def staging?
     self.tags ||= []
     self.tags.include?('staging')

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -16,6 +16,8 @@ class Version
   embedded_in :versionable, polymorphic: true
   delegate :name, :strategy, :file_name, to: :versionable
 
+  validates :message, presence: true
+
   def staging?
     self.tags ||= []
     self.tags.include?('staging')

--- a/app/views/parsers/_form.html.erb
+++ b/app/views/parsers/_form.html.erb
@@ -3,11 +3,13 @@
     <%= f.text_area :content, class: "code-editor read" %>
 
     <% if @parser.errors.any? %>
-      <span class="error">The parser version message is required.</span>
+      <% if @parser.versions.last.errors.include? :message %>
+        <small class="error">The parser version message is required.</small>
+      <% end %>
     <% end %>
 
-    <%= f.label :message %>
-    <%= f.text_field :message, required: true %>
+    <%= f.label :message, required: true %>
+    <%= f.text_field :message %>
     <%= f.submit class: 'button' %>
   <% else %>
     <%= f.text_area :content, class: "code-editor read-only" %>

--- a/app/views/parsers/_form.html.erb
+++ b/app/views/parsers/_form.html.erb
@@ -2,12 +2,6 @@
   <% if can? :update, @parser %>
     <%= f.text_area :content, class: "code-editor read" %>
 
-    <% if @parser.errors.any? %>
-      <% if @parser.versions.last.errors.include? :message %>
-        <small class="error">The parser version message is required.</small>
-      <% end %>
-    <% end %>
-
     <%= f.label :message %>
     <%= f.text_field :message, required: true %>
     <%= f.submit class: 'button' %>

--- a/app/views/parsers/_form.html.erb
+++ b/app/views/parsers/_form.html.erb
@@ -2,8 +2,12 @@
   <% if can? :update, @parser %>
     <%= f.text_area :content, class: "code-editor read" %>
 
+    <% if @parser.errors.any? %>
+      <span class="error">The parser version message is required.</span>
+    <% end %>
+
     <%= f.label :message %>
-    <%= f.text_field :message %>
+    <%= f.text_field :message, required: true %>
     <%= f.submit class: 'button' %>
   <% else %>
     <%= f.text_area :content, class: "code-editor read-only" %>

--- a/app/views/parsers/_form.html.erb
+++ b/app/views/parsers/_form.html.erb
@@ -8,8 +8,8 @@
       <% end %>
     <% end %>
 
-    <%= f.label :message, required: true %>
-    <%= f.text_field :message %>
+    <%= f.label :message %>
+    <%= f.text_field :message, required: true %>
     <%= f.submit class: 'button' %>
   <% else %>
     <%= f.text_area :content, class: "code-editor read-only" %>

--- a/app/views/snippets/_form.html.erb
+++ b/app/views/snippets/_form.html.erb
@@ -2,8 +2,14 @@
   <% if can? :update, @snippet %>
     <%= f.text_area :content, class: 'code-editor' %>
 
+    <% if @snippet.errors.any? %>
+      <% if @snippet.versions.last.errors.include? :message %>
+        <small class="error">The snippet version message is required.</small>
+      <% end %>
+    <% end %>
+
     <%= f.label :message %>
-    <%= f.text_field :message %>
+    <%= f.text_field :message, required: true %>
 
     <%= f.submit class: 'button' %>
   <% else %>

--- a/app/views/snippets/_form.html.erb
+++ b/app/views/snippets/_form.html.erb
@@ -1,13 +1,6 @@
 <%= custom_form_with model: @snippet, local: true do |f| %>
   <% if can? :update, @snippet %>
     <%= f.text_area :content, class: 'code-editor' %>
-
-    <% if @snippet.errors.any? %>
-      <% if @snippet.versions.last.errors.include? :message %>
-        <small class="error">The snippet version message is required.</small>
-      <% end %>
-    <% end %>
-
     <%= f.label :message %>
     <%= f.text_field :message, required: true %>
 

--- a/spec/factories/parsers.rb
+++ b/spec/factories/parsers.rb
@@ -6,6 +6,8 @@ FactoryBot.define do
     strategy  { 'xml' }
     content   { 'class NZMuseums < SupplejackCommon::Xml::Base; end' }
     data_type { 'record' }
+    message { 'test message' }
+    
     source
 
     trait :enrichment do

--- a/spec/factories/parsers.rb
+++ b/spec/factories/parsers.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     content   { 'class NZMuseums < SupplejackCommon::Xml::Base; end' }
     data_type { 'record' }
     message { 'test message' }
-    
     source
 
     trait :enrichment do

--- a/spec/models/concerns/versioned_spec.rb
+++ b/spec/models/concerns/versioned_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Versioned do
       before(:each) do
         parser.save
         @version = parser.versions.first
+        @version.message = 'Version'
       end
 
       context 'content has not changed' do
@@ -63,7 +64,7 @@ RSpec.describe Versioned do
 
         it 'it should #save_with_version after save' do
           expect(parser).to receive(:save_with_version)
-          parser.save
+          parser.save!
         end
       end
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -15,25 +15,6 @@ RSpec.describe Version do
     version.user = build(:user, email: 'test@test.co.nz')
   end
 
-  describe 'validations' do
-    context 'Invalid Version' do
-      let(:invalid_version) { build(:version, message: nil) }
-
-      it 'requires a message to be present' do
-        expect(invalid_version).to_not be_valid
-      end
-
-      it 'includes message in the errors array' do
-        invalid_version.valid?
-        expect(invalid_version.errors[:message]).to include "can't be blank"
-      end
-    end
-
-    it 'can be valid' do
-      expect(version).to be_valid
-    end
-  end
-
   describe '#staging?' do
     context 'has staging tag' do
       before { version.tags = ['staging'] }

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Version do
     context 'Invalid Version' do
       let(:invalid_version) { build(:version, message: nil) }
 
-      it 'requires message to be valid' do
+      it 'requires a message to be present' do
         expect(invalid_version).to_not be_valid
       end
 

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -8,11 +8,30 @@ end
 
 RSpec.describe Version do
   let(:program) { Program.new }
-  let(:version) { Version.new }
+  let(:version) { build(:version) }
 
   before do
     version.versionable = program
     version.user = build(:user, email: 'test@test.co.nz')
+  end
+
+  describe 'validations' do
+    context 'Invalid Version' do
+      let(:invalid_version) { build(:version, message: nil) }
+
+      it 'requires message to be valid' do
+        expect(invalid_version).to_not be_valid
+      end
+
+      it 'includes message in the errors array' do
+        invalid_version.valid?
+        expect(invalid_version.errors[:message]).to include "can't be blank"
+      end
+    end
+
+    it 'can be valid' do
+      expect(version).to be_valid
+    end
   end
 
   describe '#staging?' do


### PR DESCRIPTION
Acceptance Criteria

Harvest operators are not able to save empty parser version names
Harvest operator is informed that the name/message field is not allowed to be empty