### PR TITLE
SJ - PARSER DATA SOURCE DROP-DOWN FORM BUG

### DIFF
--- a/app/assets/javascripts/parsers.js
+++ b/app/assets/javascripts/parsers.js
@@ -85,6 +85,11 @@ $(function() {
     var partner = $('select[name="parser[partner]"]').val();
     $('select[name="parser[source_id]"] optgroup').remove();
     $('select[name="parser[source_id]"]').append($stored_sources);
+
+    // set the active item.
+    var currentSourceId = $("label[for='parser_source']").data('currentSourceId');
+    $('#parser_source_id').val(currentSourceId);
+
     if (partner !== "") {
       return $("select[name=\"parser[source_id]\"] optgroup[label!='" + partner + "']").remove();
     }
@@ -95,8 +100,6 @@ $(function() {
   $('select[name="parser[partner]"]').change(function() {
     update_source_from_contributor_value($stored_sources)
   });
-
-
 
   return $('#parsers').dataTable({
     "processing": true,

--- a/app/views/parsers/_parser.html.erb
+++ b/app/views/parsers/_parser.html.erb
@@ -162,7 +162,7 @@
   <%= custom_form_with model: @parser, local: true do |f| %>
     <%= f.label :partner, 'Contributor' %>
     <%= f.select :partner, Partner.all.sort(name: 1).map { |p| [p.name, p.name] }, selected: @parser.partner.name %>
-    <%= f.label :source, 'Data source' %>
+    <%= f.label :source, 'Data source', data: { 'current_source_id': @parser.source_id } %>
     <%= f.grouped_collection_select(:source_id, Partner.all, :sources, :name, :id, :source_id) %>
     <%= f.submit 'Change source', class: 'button' %>
   <% end %>


### PR DESCRIPTION
**Acceptance Criteria**
- "change data source" button should show data source pre-selected on current data source
https://manager.digitalnz.org/parsers/5dc135ac6f7fe178ce949c62/edit

**Notes**
- Currently the data source drop-down is pre populated with the top option.
It should instead show the current data source (which in the above link should be "atl")
