### PR TITLE
Update strong params to handle missing top level key

### DIFF
--- a/app/controllers/parser_versions_controller.rb
+++ b/app/controllers/parser_versions_controller.rb
@@ -49,6 +49,9 @@ class ParserVersionsController < ApplicationController
     end
 
     def parser_version_params
+      # Rails removes empty arrays from params so no top level key
+      return {} if params[:version].blank?
+
       params
         .require(:version)
         .moderate(controller_name, action_name, :content, tags: [])

--- a/spec/controllers/parser_versions_controller_spec.rb
+++ b/spec/controllers/parser_versions_controller_spec.rb
@@ -50,8 +50,11 @@ RSpec.describe ParserVersionsController do
 
   describe 'PUT update' do
     it 'updates the version' do
-      expect(version).to receive(:update_attributes).with('tags' => ['staging'])
       put :update, params: { id: 1, parser_id: 1, version: { tags: ['staging'] } }
+      expect(version.tags).to eq ['staging']
+
+      put :update, params: { id: 1, parser_id: 1, version: { tags: [] } }
+      expect(version.tags).to eq []
     end
 
     it 'redirects to the version path' do


### PR DESCRIPTION
Rails path helpers remove empty arrays from params

```
parser_parser_version_path(@parser, @version, version: {tags: ['staging']})
#=> "/parsers/5e9f8a188ebfc51fcbd99292/versions/5e9fb3258ebfc51fcbd99295?version%5Btags%5D%5B%5D=staging"

parser_parser_version_path(@parser, @version, version: {tags: []})
#=> "/parsers/5e9f8a188ebfc51fcbd99292/versions/5e9fb3258ebfc51fcbd99295"
```

Note that the last one has no `version` in the params, making `params.require(:version)` fail