### PR TITLE
REMOVE THE APM FROM ALL APPS: Part 2

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -49,8 +49,8 @@ if Rails.env.staging? || Rails.env.production?
     # A list of parameters that should be filtered out of what is sent to
     # Airbrake. By default, all "password" attributes will have their contents
     # replaced.
-    # https://github.com/airbrake/airbrake-ruby#blacklist_keys
-    c.blacklist_keys = [/password/i]
+    # https://github.com/airbrake/airbrake-ruby#blocklist_keys
+    c.blocklist_keys = [/password/i]
   end
 end
 #


### PR DESCRIPTION
[REMOVE THE APM FROM ALL APPS: As Dan, I want to remove all the apm from our system, so that we are not wasting resources on unused functionality](https://www.pivotaltracker.com/story/show/174183777)

STORY
=====

**Acceptance Criteria**
- The APM server is removed
- The elastic-apm gem is removed from all apps
- Airbrake is upgraded to its latest version

**Notes**
- We will look into replacing the APM functionality with something more fit for purpose.

**Assumptions**
- This will result in less resources in ElasticSearch which will solve our disk space issues. 
- This might save some money? transfer costs? ES disk size? 

WHAT WAS DONE
==============

- Airbrake renamed the configuration anme