### PR TITLE
SJ HARVEST JOBS INTERFACE TWEAKS: As Ting I want some new buttons and some streamlining of SJ harvest info, so that its easy to understand and view the results of my harvesting

### DIFF
--- a/app/assets/stylesheets/blocks/_base.scss
+++ b/app/assets/stylesheets/blocks/_base.scss
@@ -87,3 +87,8 @@ select {
     padding-right: 2rem;
   }
 }
+
+.failed {
+  font-weight: $global-weight-bold;
+  color: get-color('warning');
+}

--- a/app/assets/stylesheets/blocks/_base.scss
+++ b/app/assets/stylesheets/blocks/_base.scss
@@ -88,7 +88,7 @@ select {
   }
 }
 
-.failed {
+.warning {
   font-weight: $global-weight-bold;
   color: get-color('warning');
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -66,10 +66,10 @@ module ApplicationHelper
     return '' unless secs.present?
 
     secs = secs.to_i
-    [[60, :seconds],
-     [60, :minutes],
-     [24, :hours],
-     [Float::INFINITY, :days]].map do |count, name|
+    [[60, :sec],
+     [60, :min],
+     [24, :hr],
+     [Float::INFINITY, :day]].map do |count, name|
       next unless secs.positive?
 
       secs, n = secs.divmod(count)

--- a/app/views/abstract_jobs/index.html.erb
+++ b/app/views/abstract_jobs/index.html.erb
@@ -75,7 +75,7 @@
         <% if params[:status] == 'all' %>
           <td>
             <% status = abstract_job.status.capitalize %>
-            <span class="<%= status == 'Failed' ? 'failed' : '' %>">
+            <span class="<%= status == 'Failed' ? 'warning' : '' %>">
               <%= status %>
             </span>
           </td>

--- a/app/views/abstract_jobs/index.html.erb
+++ b/app/views/abstract_jobs/index.html.erb
@@ -61,7 +61,12 @@
         <% end %>
 
         <% if params[:status] == 'all' %>
-          <td><%= abstract_job.status.capitalize %></td>
+          <td>
+            <% status = abstract_job.status.capitalize %>
+            <span class="<%= status == 'Failed' ? 'failed' : '' %>">
+              <%= status %>
+            </span>
+          </td>
         <% end %>
 
         <td>

--- a/app/views/abstract_jobs/index.html.erb
+++ b/app/views/abstract_jobs/index.html.erb
@@ -15,7 +15,7 @@
         <th><%= t("harvest_jobs.enrichment") %></th>
         <th><%= t("harvest_jobs.operator") %></th>
         <th><%= t("harvest_jobs.start_time") %></th>
-        <% if params[:status] == "finished" %>
+        <% if %w[finished all].include?(params[:status]) %>
           <th><%= t("harvest_jobs.duration") %></th>
         <% end %>
 
@@ -48,7 +48,7 @@
         <% end %>
         <td><%= l abstract_job.try(:start_time), format: :long rescue nil %></td>
 
-        <% if params[:status] == "finished" %>
+        <% if %w[finished all].include?(params[:status]) %>
           <td><%= human_duration(abstract_job.duration) %></td>
         <% end %>
 

--- a/app/views/abstract_jobs/index.html.erb
+++ b/app/views/abstract_jobs/index.html.erb
@@ -9,7 +9,7 @@
   <table>
     <thead>
       <tr>
-        <th><%= t("abstract_jons.type") %></th>
+        <th></th>
         <th><%= t("harvest_jobs.parser") %></th>
         <th><%= t("harvest_jobs.mode") %></th>
         <th><%= t("harvest_jobs.enrichment") %></th>
@@ -33,7 +33,19 @@
     <tbody>
       <% @abstract_jobs.each do |abstract_job| %>
       <tr>
-        <td><%= t("abstract_jobs.#{abstract_job._type.downcase}") %></td>
+        <td>
+          <%=
+            link_to(
+              '&#128269;'.html_safe,
+              environment_abstract_jobs_path(
+                params[:environment],
+                status: params['status'],
+                parser_id: abstract_job.parser.id
+              ),
+              title: 'Filter to show only jobs from this parser'
+            )
+          %>
+        </td>
         <% if abstract_job.version_id.present? %>
           <td><%= link_to abstract_job.parser_name, parser_parser_version_path(abstract_job.parser_id, abstract_job.version_id) %></td>
         <% else %>

--- a/app/views/abstract_jobs/index.html.erb
+++ b/app/views/abstract_jobs/index.html.erb
@@ -58,7 +58,7 @@
         <% else %>
           <td><%= t("harvest_jobs.scheduled") %></td>
         <% end %>
-        <td><%= l abstract_job.try(:start_time), format: :long rescue nil %></td>
+        <td><%= l abstract_job&.start_time, format: :start_time rescue nil %></td>
 
         <% if %w[finished all].include?(params[:status]) %>
           <td><%= human_duration(abstract_job.duration) %></td>

--- a/app/views/parsers/_parser.html.erb
+++ b/app/views/parsers/_parser.html.erb
@@ -34,7 +34,7 @@
     <ul class="harvest-commands">
       <li class="medium-12 cell">
         <button class="button dropdown medium-12 expanded" data-toggle='harvests-jobs-dropdown'>
-          View all harvests jobs from this parser
+          View all jobs from this parser
         </button>
 
         <div class='dropdown-pane' id='harvests-jobs-dropdown' data-dropdown data-auto-focus='true'>

--- a/app/views/parsers/_parser.html.erb
+++ b/app/views/parsers/_parser.html.erb
@@ -32,6 +32,31 @@
   <div class="medium-3 cell">
 
     <ul class="harvest-commands">
+      <li class="medium-12 cell">
+        <button class="button dropdown medium-12 expanded" data-toggle='harvests-jobs-dropdown'>
+          View all harvests jobs from this parser
+        </button>
+
+        <div class='dropdown-pane' id='harvests-jobs-dropdown' data-dropdown data-auto-focus='true'>
+          <ul class='no-bullet'>
+            <% APPLICATION_ENVS.each do |env| %>
+              <li>
+                <%=
+                  link_to(
+                    "#{env.capitalize} jobs",
+                    environment_abstract_jobs_path(
+                      env.downcase,
+                      status: 'all',
+                      parser_id: @parser.id,
+                    ),
+                    target: '_blank'
+                  )
+                %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </li>
       <% if can? :run_harvest, @parser %>
         <% if @version %>
           <li class="medium-12 cell">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   time:
     formats:
       first_run_at: "%d %b %Y"
+      start_time: "%b %d, %Y %H:%M"
 
   environments:
     production: "Production"

--- a/spec/features/dashboards/abstract_job_spec.rb
+++ b/spec/features/dashboards/abstract_job_spec.rb
@@ -113,6 +113,12 @@ RSpec.feature 'Abstract Job Dashboard', type: :feature do
         expect(page).to have_content('Finished')
         expect(page).to have_content('Active')
         expect(page).to have_content('Duration')
+
+        expect(page.find('td:first-child a')[:href]).to include environment_abstract_jobs_path(
+          'staging',
+          status: 'all',
+          parser_id: abstract_job.parser.id
+        )
       end
     end
   end

--- a/spec/features/dashboards/abstract_job_spec.rb
+++ b/spec/features/dashboards/abstract_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.feature 'Abscrtract Job Dashboard', type: :feature do
+RSpec.feature 'Abstract Job Dashboard', type: :feature do
   context 'a user that is logged out' do
     scenario 'gets redirected to the sign in page' do
       visit environment_abstract_jobs_path(environment: 'staging')
@@ -112,6 +112,7 @@ RSpec.feature 'Abscrtract Job Dashboard', type: :feature do
         expect(page).to have_content('Status')
         expect(page).to have_content('Finished')
         expect(page).to have_content('Active')
+        expect(page).to have_content('Duration')
       end
     end
   end

--- a/spec/features/parsers/manage_parser_scripts_spec.rb
+++ b/spec/features/parsers/manage_parser_scripts_spec.rb
@@ -80,6 +80,20 @@ RSpec.feature 'Manage parser', type: :feature, js: true do
       expect(page).to have_content("class #{new_parser.name} < SupplejackCommon::Oai::Base")
     end
 
+    scenario 'displays a link to the jobs page' do
+      select 'OAI'
+      click_button 'Create Parser Script'
+
+      click_button 'View all harvests jobs from this parser'
+      link = page.find_link 'Staging jobs'
+      expect(link[:target]).to eq '_blank'
+      expect(link[:href]).to include environment_abstract_jobs_path(
+        'staging',
+        status: 'all',
+        parser_id: page.current_path.split('/')[2],
+      )
+    end
+
     scenario 'create parser from a template' do
       select 'JSON'
       select parser_template.name

--- a/spec/features/parsers/manage_parser_scripts_spec.rb
+++ b/spec/features/parsers/manage_parser_scripts_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature 'Manage parser', type: :feature, js: true do
       select 'OAI'
       click_button 'Create Parser Script'
 
-      click_button 'View all harvests jobs from this parser'
+      click_button 'View all jobs from this parser'
       link = page.find_link 'Staging jobs'
       expect(link[:target]).to eq '_blank'
       expect(link[:href]).to include environment_abstract_jobs_path(


### PR DESCRIPTION
[SJ HARVEST JOBS INTERFACE TWEAKS: As Ting I want some new buttons and some streamlining of SJ harvest info, so that its easy to understand and view the results of my harvesting](https://www.pivotaltracker.com/story/show/173721413)

STORY
=====

**Acceptance Criteria**
- On the ["all" tab](https://manager.digitalnz.org/production/jobs?status=all) `/jobs?status=all`
 - Duration column is visible (which you can see for the other status's). Active jobs can leave cell empty.
 - ["Failed"](https://manager.digitalnz.org/production/jobs?parser_id=561ac733297b1f7442000003&status=all) status jobs have the word "Failed" highlighted (bold+red?)
- On any jobs page `/jobs....`
 - Duration information is steamlined to "x day x hr xx min xx sec" (eg "minutes" to "min")
 - Remove first "Type" column (which in the end is being replaced with the next item on this list)
 - First column (with no title) contains🔎 icon as a link to [?status=all&parser_id=xxxxx](https://manager.digitalnz.org/production/jobs?status=all&parser_id=55c80c96297b1fc31b000005) for each parser listed. See attached screen shot
 - Tooltip / hover info on the magnifying glass saying 
"filter to show only jobs from this parser"
 - "First Run at" column month name shortened to 3 letters. eg October 30... becomes Oct 30...
- On [individual parser pages](https://manager.digitalnz.org/parsers/5bb16397297b1f54f7416609/edit) `/parsers/...`(including urls for versions, edit, etc)
 - Button added top of right side section
"View all harvest jobs from this parser" (with dropdown)
(Links open in a new tab)
   - "Production jobs"
   - "Staging jobs"

SCREENSHOTS
=============

Harvest jobs page
-------------------------

Before:

![image](https://user-images.githubusercontent.com/4416830/100257837-a6f19b00-2f46-11eb-9282-0f230bff9e61.png)

After:

![image](https://user-images.githubusercontent.com/4416830/100257759-93463480-2f46-11eb-85f7-847a134cc78e.png)

Job details page
----------------------

Before:

![image](https://user-images.githubusercontent.com/4416830/100258038-de604780-2f46-11eb-8c85-9948bbe295a3.png)

After:

![image](https://user-images.githubusercontent.com/4416830/100258071-e7e9af80-2f46-11eb-8094-3154df2681c2.png)

Parser page
-----------------

Before:

![image](https://user-images.githubusercontent.com/4416830/100258140-fd5ed980-2f46-11eb-83ed-6f5f85df5fee.png)

After:

![image](https://user-images.githubusercontent.com/4416830/100258183-0c458c00-2f47-11eb-85be-16ed1ff8c9fb.png)



