### PR TITLE
FIX: BROKEN VERSIONS

### DIFF
--- a/app/helpers/parsers_helper.rb
+++ b/app/helpers/parsers_helper.rb
@@ -2,6 +2,10 @@
 
 # Helpers for Parsers
 module ParsersHelper
+  def version_message(parser, version = nil)
+    version.nil? ? parser.versions.last.message : version.message
+  end
+
   # Returns the next link for preview view
   #
   # @author Federico Gonzalez

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -3,7 +3,7 @@
 class Version
   include Mongoid::Document
   include Mongoid::Timestamps::Created
-  # include Mongoid::Paranoia
+  include Mongoid::Paranoia
   include Mongoid::Attributes::Dynamic
 
   field :content,   type: String
@@ -15,6 +15,8 @@ class Version
 
   embedded_in :versionable, polymorphic: true
   delegate :name, :strategy, :file_name, to: :versionable
+
+  default_scope -> { not_in(version: nil) }
 
   def staging?
     self.tags ||= []

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -3,7 +3,7 @@
 class Version
   include Mongoid::Document
   include Mongoid::Timestamps::Created
-  include Mongoid::Paranoia
+  # include Mongoid::Paranoia
   include Mongoid::Attributes::Dynamic
 
   field :content,   type: String

--- a/app/views/parsers/_parser.html.erb
+++ b/app/views/parsers/_parser.html.erb
@@ -116,8 +116,10 @@
       <% end %>
     </ul>
 
+    <div class="callout secondary text-center" data-alert="">
+      <%= 'Current  version: ' + (@version.nil? ?  @parser.versions.last&.message || 'No versions created yet' : @version.message)  %>
+    </div>
 
-    <div class="callout secondary text-center" data-alert=""><%= 'Current  version: ' + (@version.nil? ?  @parser.versions.last.message : @version.message)  %></div>
     <% if can? :run_harvest, @parser %>
       <%= link_to t("parsers.edit_current"), edit_parser_path(@parser), class: "button production medium-12 cell" %>
     <% end %>

--- a/app/views/parsers/_parser.html.erb
+++ b/app/views/parsers/_parser.html.erb
@@ -117,7 +117,7 @@
     </ul>
 
     <div class="callout secondary text-center" data-alert="">
-      <%= 'Current  version: ' + (@version.nil? ?  @parser.versions.last&.message || 'No versions created yet' : @version.message)  %>
+      <%= 'Current  version: ' + version_message(@parser, @version)  %>
     </div>
 
     <% if can? :run_harvest, @parser %>
@@ -160,7 +160,7 @@
     Are you sure that you want to delete the parser:
     <strong><%= @parser.name %></strong>
     with version name:
-    <strong><%= @version ? @version.message : @parser.versions.last.message %></strong>?
+    <strong><%= version_message(@parser, @version) %></strong>?
   </p>
   <% if @parser.scheduled? %>
     <p> <strong>Warning:</strong> You currently have scheduled jobs set for this parser. By deleting this parser the scheduled jobs will be deleted as well. </p>

--- a/spec/factories/version.rb
+++ b/spec/factories/version.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     user_id   { '577d8c270403714b67000001' }
     content   { 'class NZMuseums; end' }
 
+    user
+
     trait :santos do
       tags { ['santos clause'] }
     end

--- a/spec/features/harvesting/enrichment_spec.rb
+++ b/spec/features/harvesting/enrichment_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature 'Enrichment Spec', js: true do
   let(:user)    { create(:user, :admin) }
   let(:source)  { create(:source) }
   let!(:enrichment) { create(:parser, :enrichment, source_id: source) }
-  let!(:version) { create(:version, :enrichment, versionable: enrichment, user_id: user, tags: ['staging']) }
+  let!(:version) { create(:version, :enrichment, versionable: enrichment, user_id: user, tags: ['staging'], version: 'v3') }
 
   before do
     sign_in user

--- a/spec/features/harvesting/harvest_spec.rb
+++ b/spec/features/harvesting/harvest_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Harvesting', type: :feature, js: true do
   let(:user)    { create(:user, :admin) }
   let(:source)  { create(:source) }
   let!(:parser) { create(:parser, source_id: source) }
-  let!(:version) { create(:version, versionable: parser, user_id: user) }
+  let!(:version) { create(:version, versionable: parser, user_id: user, version: 'v5') }
 
   before do
     sign_in user

--- a/spec/features/harvesting/harvest_spec.rb
+++ b/spec/features/harvesting/harvest_spec.rb
@@ -70,8 +70,8 @@ RSpec.feature 'Harvesting', type: :feature, js: true do
   scenario 'A harvest operator can Update a parser' do
     fill_code_mirror 'class Hey; end'
     fill_in 'parser_message', with: 'Updating Parser'
-
     click_button 'Update Parser Script'
+
     expect(page).to have_link 'Updating Parser'
   end
 
@@ -79,15 +79,18 @@ RSpec.feature 'Harvesting', type: :feature, js: true do
     click_button 'Rename Parser'
     fill_in 'parser_name', with: 'Parser Name'
     click_button 'Rename'
+
     expect(page).to have_link 'Parser Name'
   end
 
   scenario 'A harvest operator can change the data source of a parser' do
     click_button('Change Data Source')
+
     expect(page).to have_text 'Change source'
     expect(page).to have_text 'Warning: changing the source of this parser does not affect records that have already been harvested.'
     expect(page).to have_text 'Contributor'
     expect(page).to have_text ' Data Source'
+
     click_button 'Change source'
   end
 
@@ -95,6 +98,7 @@ RSpec.feature 'Harvesting', type: :feature, js: true do
     allow(HarvestSchedule).to receive(:update_schedulers_from_environment) { true }
     click_link 'Disable Full & Flush harvest mode'
     page.driver.browser.switch_to.alert.accept
+
     expect(page).to have_text 'Enable Full & Flush harvest mode'
   end
 
@@ -107,6 +111,7 @@ RSpec.feature 'Harvesting', type: :feature, js: true do
       expect(page).to have_text "#{parser.name}"
       expect(page).to have_text 'with version name:'
     end
+
     expect(page).to have_text 'Warning:'
     expect(page).to have_text 'You currently have scheduled jobs set for this parser.'
     expect(page).to have_text 'By deleting this parser the scheduled jobs will be deleted as well.'

--- a/spec/helpers/parsers_helper_spec.rb
+++ b/spec/helpers/parsers_helper_spec.rb
@@ -7,9 +7,24 @@ RSpec.describe ParsersHelper do
     allow_any_instance_of(Partner).to receive(:update_apis)
     allow_any_instance_of(Source).to receive(:update_apis)
     allow(LinkCheckRule).to receive(:create)
-    build(:parser)
+    
+    create(:parser)
   end
-  let(:version) { build(:version, versionable: parser, tags: ['production']) }
+  let(:version) { build(:version, versionable: parser, tags: ['production'], message: Faker::Lorem.word, version: 'v2') }
+
+  describe '#version_message' do
+    context 'when version is nil' do
+      it 'returns message from last version of the parser' do
+        expect(helper.version_message(parser, nil)).to eq parser.versions.last.message
+      end
+    end
+
+    context 'when version is not nil' do
+      it 'returns message from last version of the parser' do
+        expect(helper.version_message(parser, version)).to eq version.message
+      end
+    end
+  end
 
   describe '#version_tags' do
     context 'current production tag' do

--- a/spec/helpers/parsers_helper_spec.rb
+++ b/spec/helpers/parsers_helper_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe ParsersHelper do
     allow_any_instance_of(Partner).to receive(:update_apis)
     allow_any_instance_of(Source).to receive(:update_apis)
     allow(LinkCheckRule).to receive(:create)
-    
     create(:parser)
   end
   let(:version) { build(:version, versionable: parser, tags: ['production'], message: Faker::Lorem.word, version: 'v2') }

--- a/spec/models/parser_spec.rb
+++ b/spec/models/parser_spec.rb
@@ -167,9 +167,7 @@ RSpec.describe Parser do
     end
 
     context 'when version is not passed but the parser has a tagged version' do
-      before(:each) do
-        parser.versions << build(:version, :staging)
-      end
+      before { parser.versions << build(:version, :staging, version: 'v1') }
 
       it 'parser is set as the content of the last tagged version' do
         parser.enrichment_definitions('staging')
@@ -256,7 +254,7 @@ RSpec.describe Parser do
 
   describe '#updated_last_editor' do
     let(:user)    { create(:user) }
-    let(:version) { build(:version, :staging, user: user) }
+    let(:version) { build(:version, :staging, user: user, version: 'v1') }
     let(:parser)  { create(:parser) }
 
     it 'sets the user as the last edited by before a parser is saved' do


### PR DESCRIPTION
`null` versions were created for a parser, this should never happen. A version is created on an after_create hook defined in Versioned module. The after save simply creates a new version with count + 1 was the version number, user and message from the parser update.

To prevent the app from encountering any more `null` versions and throwing error a default_scope is added to the version.