### PR TITLE
REMOVE THE LAST CODERAY CALL ON MANAGER: As Haki the harvester, I want to remove the last CodeRay call, so that the preview is not bugged

### DIFF
--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -52,10 +52,6 @@ class Preview < ActiveResource::Base
     JSON.parse(self.field_errors).any? unless self.field_errors.nil?
   end
 
-  def field_errors_output
-    CodeRay.scan(field_errors_json, :json).html(line_numbers: :table).html_safe if field_errors?
-  end
-
   def validation_errors_output
     JSON.parse(self.validation_errors) unless self.validation_errors.nil?
   end

--- a/app/views/previewers/_previewer.erb
+++ b/app/views/previewers/_previewer.erb
@@ -20,7 +20,7 @@
 
       <div id="field-errors" class="hidden">
         <h4>Field Errors</h4>
-        <p></p>
+        <textarea class="code-editor-multiple read-only"></textarea>
       </div>
 
       <div id="harvest-errors" class="hidden">

--- a/app/views/previews/show.js.erb
+++ b/app/views/previews/show.js.erb
@@ -14,7 +14,7 @@ $('#preview-<%= @preview.id %> #status').html("<%= escape_javascript(@preview.st
 		readOnly: true,
 		mode: 'text/x-ruby',
 		lineSeperator: ','
-	}) 
+	})
 
 	$('#source-data-label').click(function() {
 		setTimeout(function() {
@@ -69,8 +69,15 @@ $('#preview-<%= @preview.id %> #status').html("<%= escape_javascript(@preview.st
 
 <% if @preview.field_errors? %>
 	$('#preview-<%= @preview.id %> #status').html("Field Errors");
-	$('#preview-<%= @preview.id %> #field-errors p').html("<%= escape_javascript(@preview.field_errors_output) %>");
+	$('#preview-<%= @preview.id %> #field-errors .code-editor-multiple').html("<%= escape_javascript(@preview.field_errors) %>");
 	$('#preview-<%= @preview.id %> #field-errors').show();
+	window.CodeMirror.fromTextArea($('#preview-<%= @preview.id %> #field-errors .code-editor-multiple')[0], {
+    lineNumbers: true,
+    theme: 'monokai',
+    tabSize: 2,
+    readOnly: true,
+    lineSeperator: ',',
+  })
 <% end %>
 
 <% if @preview.deletable? %>

--- a/spec/models/preview_spec.rb
+++ b/spec/models/preview_spec.rb
@@ -36,25 +36,6 @@ RSpec.describe Preview do
     end
   end
 
-  describe '#field_errors_output' do
-    let(:field_errors_json) { JSON.pretty_generate('title': 'Invalid!') }
-
-    before do
-      allow(preview).to receive(:field_errors?) { true }
-      allow(preview).to receive(:field_errors_json) { field_errors_json }
-    end
-
-    it 'returns highlighted json' do
-      output = %q{{\n  <span class=\"key\"><span class=\"delimiter\">&quot;</span><span class=\"content\">title</span><span class=\"delimiter\">&quot;</span></span>: <span class=\"string\"><span class=\"delimiter\">&quot;</span><span class=\"content\">Invalid!</span><span class=\"delimiter\">&quot;</span></span>\n}}
-      expect(preview.field_errors_output).to match(output)
-    end
-
-    it 'returns nil when there are no field_errors' do
-      allow(preview).to receive(:field_errors?) { false }
-      expect(preview.field_errors_output).to be nil
-    end
-  end
-
   describe '#validation_errors?' do
     it 'returns false when there are no validation_errors' do
       allow(preview).to receive(:validation_errors)


### PR DESCRIPTION
[REMOVE THE LAST CODERAY CALL ON MANAGER: As Haki the harvester, I want to remove the last CodeRay call, so that the preview is not bugged](https://www.pivotaltracker.com/story/show/178846389)

STORY
=====


**Acceptance Criteria**
- The CodeRay string is not present in the manager


**Risks**
- <Any risks?>

**Notes**
- https://digitalnz.airbrake.io/projects/124736/groups/3007095430354046423?filters=%7B%22order%22%3A%22notice_count%22%2C%22resolved%22%3A%22false%22%7D&tab=overview
- I couldn't find a way to reproduce 
- Follows https://www.pivotaltracker.com/story/show/177940129

**Tests**
- The preview is working with syntax highlighting