### PR TITLE
API KEY IN HEADER FOR SJ MANAGER: As Sasha, I want Supplejack Manager to use HTTP-header based authentication for making API requests, so that the API keys are kept secret

### DIFF
--- a/app/api/api/activity.rb
+++ b/app/api/api/activity.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Api
+  class Activity < Request
+    def self.index(env)
+      Api::Request.new(
+        '/harvester/activities',
+        env
+      ).get
+    end
+  end
+end

--- a/app/api/api/api_user.rb
+++ b/app/api/api/api_user.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Api
+  class ApiUser < Request
+    def self.index(env)
+      Api::Request.new(
+        '/harvester/users',
+        env
+      ).get
+    end
+
+    def self.get(env, user_id, params)
+      Api::Request.new(
+        "/harvester/users/#{user_id}",
+        env,
+        params
+      ).get
+    end
+
+    def self.patch(env, user_id, params)
+      Api::Request.new(
+        "/harvester/users/#{user_id}",
+        env,
+        params
+      ).patch
+    end
+  end
+end

--- a/app/api/api/partner.rb
+++ b/app/api/api/partner.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Api
+  class Partner < Request
+    def self.post(env, params)
+      Api::Request.new('/harvester/partners', env, params).post
+    end
+  end
+end

--- a/app/api/api/partner_sources.rb
+++ b/app/api/api/partner_sources.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  class PartnerSources < Request
+    def self.post(env, partner_id, params)
+      Api::Request.new(
+        "/harvester/partners/#{partner_id}/source",
+        env,
+        params
+      ).post
+    end
+  end
+end

--- a/app/api/api/partner_sources.rb
+++ b/app/api/api/partner_sources.rb
@@ -4,7 +4,7 @@ module Api
   class PartnerSources < Request
     def self.post(env, partner_id, params)
       Api::Request.new(
-        "/harvester/partners/#{partner_id}/source",
+        "/harvester/partners/#{partner_id}/sources",
         env,
         params
       ).post

--- a/app/api/api/record.rb
+++ b/app/api/api/record.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  class Record < Request
+    def self.get(env, record_id)
+      Api::Request.new("/harvester/records/#{record_id}", env).get
+    end
+
+    def self.put(env, record_id, params)
+      Api::Request.new("/harvester/records/#{record_id}", env, params).put
+    end
+  end
+end

--- a/app/api/api/request.rb
+++ b/app/api/api/request.rb
@@ -6,10 +6,10 @@ module Api
 
     attr_reader :url, :token, :params
 
-    def initialize(path, env, params = nil)
+    def initialize(path, env, params = {})
       @url = "#{fetch_env_vars(env)['API_HOST']}#{path}.json"
       @token = fetch_env_vars(env)['HARVESTER_API_KEY']
-      @params = params ? { params: params } : {}
+      @params = params
     end
 
     def get
@@ -34,12 +34,21 @@ module Api
 
     private
       def execute(method)
+        if method.in?(%i[post put patch])
+          payload = @params
+          url_params = {}
+        else
+          payload = nil
+          url_params = @params.any? ? { params: @params } : {}
+        end
+
         RestClient::Request.execute(
           method: method,
           url: @url,
+          payload: payload,
           headers: {
             'Authentication-Token': @token
-          }.merge(@params)
+          }.merge(url_params)
         )
       end
   end

--- a/app/api/api/request.rb
+++ b/app/api/api/request.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Api
+  class Request
+    include EnvironmentHelpers
+
+    attr_reader :url, :token, :params
+
+    def initialize(path, env, params = nil)
+      @url = "#{fetch_env_vars(env)['API_HOST']}#{path}.json"
+      @token = fetch_env_vars(env)['HARVESTER_API_KEY']
+      @params = params ? { params: params } : {}
+    end
+
+    def get
+      execute(:get)
+    end
+
+    def post
+      execute(:post)
+    end
+
+    def put
+      execute(:put)
+    end
+
+    def patch
+      execute(:patch)
+    end
+
+    def delete
+      execute(:delete)
+    end
+
+    private
+      def execute(method)
+        RestClient::Request.execute(
+          method: method,
+          url: @url,
+          headers: {
+            'Authentication-Token': @token
+          }.merge(@params)
+        )
+      end
+  end
+end

--- a/app/api/api/source.rb
+++ b/app/api/api/source.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  class Source < Request
+    def self.index(env, params)
+      Api::Request.new('/harvester/sources', env, params).get
+    end
+
+    def self.reindex(env, source_id, params)
+      Api::Request.new("/harvester/sources/#{source_id}/reindex", env, params).get
+    end
+
+    def self.put(env, source_id, params)
+      Api::Request.new("/harvester/sources/#{source_id}", env, params).put
+    end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -26,12 +26,6 @@ module Admin
         params.permit(:max_requests, :id)
       end
 
-      def api_key
-        APPLICATION_ENVIRONMENT_VARIABLES[
-          params[:environment]
-        ]['HARVESTER_API_KEY']
-      end
-
       def page
         params[:page] || 1
       end

--- a/app/controllers/collection_records_controller.rb
+++ b/app/controllers/collection_records_controller.rb
@@ -5,13 +5,18 @@ class CollectionRecordsController < ApplicationController
 
   def index
     @record_id = params[:id]
-    @response = RestClient.get("#{fetch_env_vars['API_HOST']}/harvester/records/#{@record_id}.json", { params: { api_key: fetch_env_vars['HARVESTER_API_KEY'] } }) rescue nil
-    @record = JSON.parse(@response) rescue nil
+    if @record_id
+      @response = Api::Record.get(env, @record_id) rescue nil
+      @record = JSON.parse(@response) rescue nil
+    else
+      @response = nil
+      @record = nil
+    end
   end
 
   def update
     begin
-      RestClient.put("#{fetch_env_vars['API_HOST']}/harvester/records/#{params[:id]}", { record: { status: params[:status] }, api_key: fetch_env_vars['HARVESTER_API_KEY'] })
+      Api::Record.put(env, params[:id], { record: { status: params[:status] } })
       flash[:notice] = 'Record successfully updated'
     rescue Exception => e
       Rails.logger.error "Exception #{e} when attempting to post to API"

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,9 +2,7 @@
 
 class HomeController < ApplicationController
   def index
-    @environment = params[:environment] || session[:environment] || APPLICATION_ENVS.first.to_s
-    params[:environment] = @environment
-    session[:environment] = @environment
+    @environment = params[:environment] || APPLICATION_ENVS.first.to_s
     @stats = { active_jobs: 'n/a', finished_jobs: 'n/a', failed_jobs: 'n/a', activated: 'n/a', suppressed: 'n/a', deleted: 'n/a' }
 
     begin
@@ -21,17 +19,17 @@ class HomeController < ApplicationController
 
   private
     def gather_job_stats
-      set_worker_environment_for(AbstractJob)
+      set_worker_environment_for(AbstractJob, @environment)
 
       since_when = DateTime.now - 1
 
-      @stats[:active_jobs] = AbstractJob.find(:all, from: :jobs_since, params: { datetime: since_when, environment: params[:environment], status: 'active' }).count
-      @stats[:finished_jobs] = AbstractJob.find(:all, from: :jobs_since, params: { datetime: since_when, environment: params[:environment], status: 'finished' }).count
-      @stats[:failed_jobs] = AbstractJob.find(:all, from: :jobs_since, params: { datetime: since_when, environment: params[:environment], status: 'failed' }).count
+      @stats[:active_jobs] = AbstractJob.find(:all, from: :jobs_since, params: { datetime: since_when, environment: @environment, status: 'active' }).count
+      @stats[:finished_jobs] = AbstractJob.find(:all, from: :jobs_since, params: { datetime: since_when, environment: @environment, status: 'finished' }).count
+      @stats[:failed_jobs] = AbstractJob.find(:all, from: :jobs_since, params: { datetime: since_when, environment: @environment, status: 'failed' }).count
     end
 
     def gather_collection_stats
-      set_worker_environment_for(CollectionStatistics)
+      set_worker_environment_for(CollectionStatistics, @environment)
 
       klass = CollectionStatistics
       if klass.first
@@ -40,7 +38,7 @@ class HomeController < ApplicationController
     end
 
     def gather_harvest_schedules_stats
-      set_worker_environment_for(HarvestSchedule, params[:environment])
+      set_worker_environment_for(HarvestSchedule, @environment)
       @scheduled_jobs = HarvestSchedule.find(:all, from: :next)
     end
 end

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -51,8 +51,7 @@ class SourcesController < ApplicationController
   end
 
   def reindex
-    url = APPLICATION_ENVIRONMENT_VARIABLES[params['env']]['API_HOST']
-    RestClient.get("#{url}/harvester/sources/#{@source.id}/reindex", { params: { date: params[:date], api_key: fetch_env_vars['HARVESTER_API_KEY'] } })
+    Api::Source.reindex(env, @source.id, { date: params[:date] })
   end
 
   def source_params

--- a/app/controllers/suppress_collections_controller.rb
+++ b/app/controllers/suppress_collections_controller.rb
@@ -6,30 +6,22 @@ class SuppressCollectionsController < ApplicationController
   respond_to :html, :json
 
   def index
-    sources_url = "#{fetch_env_vars['API_HOST']}/harvester/sources"
-    blacklisted_request_options = {
-      params: {
-        'source[status]': 'suppressed',
-        api_key: fetch_env_vars['HARVESTER_API_KEY']
-      }
-    }
-    @blacklisted_response = RestClient.get(sources_url, blacklisted_request_options)
+    blacklisted_request_options = { source: { status: :suppressed } }
+    @blacklisted_response = Api::Source.index(env, blacklisted_request_options)
     @blacklisted_sources = JSON.parse(@blacklisted_response)
 
     top_10_request_options = {
-      params: {
-        'source[status]': 'active',
-        limit: 10, order_by: 'status_updated_at',
-        api_key: fetch_env_vars['HARVESTER_API_KEY']
-      }
+      source: { status: :active },
+      limit: 10,
+      order_by: :status_updated_at
     }
-    @top_10_response = RestClient.get(sources_url, top_10_request_options)
+    @top_10_response = Api::Source.index(env, top_10_request_options)
     @top_10_sources = JSON.parse(@top_10_response)
   end
 
   def update
     begin
-      RestClient.put("#{fetch_env_vars['API_HOST']}/harvester/sources/#{params[:id]}", { source: { status: params[:status], status_updated_by: current_user.name }, api_key: fetch_env_vars['HARVESTER_API_KEY'] })
+      Api::Source.put(env, params[:id], source: { status: params[:status], status_updated_by: current_user.name })
     rescue RestClient::Exception => e
       Rails.logger.error "Exception #{e} when attempting to post to API"
     end

--- a/app/javascript/stylesheets/blocks/_codemirror.scss
+++ b/app/javascript/stylesheets/blocks/_codemirror.scss
@@ -1,5 +1,3 @@
-.CodeMirror, .CodeMirror-scroll {
+.CodeMirror {
   height: auto;
-  overflow-y: hidden;
-  overflow-x: auto;
 }

--- a/app/models/admin/activity.rb
+++ b/app/models/admin/activity.rb
@@ -13,18 +13,10 @@ module Admin
     end
 
     def all
-      JSON.parse(RestClient.get("#{host}/harvester/activities.json", params: { api_key: api_key }))['site_activities']
+      response = Api::Activity.index(environment)
+      JSON.parse(response)['site_activities']
     rescue Errno::ECONNREFUSED
       []
     end
-
-    private
-      def host
-        APPLICATION_ENVIRONMENT_VARIABLES[environment]['API_HOST']
-      end
-
-      def api_key
-        APPLICATION_ENVIRONMENT_VARIABLES[environment]['HARVESTER_API_KEY']
-      end
   end
 end

--- a/app/models/admin/user.rb
+++ b/app/models/admin/user.rb
@@ -13,26 +13,19 @@ module Admin
     end
 
     def all
-      @users = JSON.parse(RestClient.get("#{host}/harvester/users.json", params: { api_key: api_key }))['users']
+      response = Api::ApiUser.index(environment)
+      @users = JSON.parse(response)['users']
     rescue Errno::ECONNREFUSED
       []
     end
 
     def find(id)
-      @user = JSON.parse(RestClient.get("#{host}/harvester/users/#{id}.json", params: { api_key: api_key, page: page }))
+      response = Api::ApiUser.get(environment, id, { page: page })
+      @user = JSON.parse(response)
     end
 
     def update(params)
-      RestClient.patch("#{host}/harvester/users/#{params['id']}.json?api_key=#{api_key}", { user: { max_requests: params['max_requests'] } })
+      Api::ApiUser.patch(environment, params['id'], { user: { max_requests: params['max_requests'] } })
     end
-
-    private
-      def host
-        APPLICATION_ENVIRONMENT_VARIABLES[environment]['API_HOST']
-      end
-
-      def api_key
-        APPLICATION_ENVIRONMENT_VARIABLES[environment]['HARVESTER_API_KEY']
-      end
   end
 end

--- a/app/models/concerns/environment_helpers.rb
+++ b/app/models/concerns/environment_helpers.rb
@@ -16,39 +16,27 @@ module EnvironmentHelpers
     end
   end
 
+  def env
+    params[:environment]
+  end
 
   def set_worker_environment_for(klass, environment = nil)
-    if environment.present?
-      env_vars = APPLICATION_ENVIRONMENT_VARIABLES[environment]
-    else
-      env_vars = fetch_env_vars
-    end
+    env = environment || params[:environment]
+    env_vars = fetch_env_vars(env)
 
     klass.site = env_vars['WORKER_HOST']
     klass.user = env_vars['WORKER_KEY']
   end
 
-
-  def fetch_env_vars(environment = nil)
-    if Rails.env.development? && params[:environment]
-      environment = params[:environment]
-    elsif Rails.env.development?
-      environment = 'development'
-    elsif params[:environment] == 'test'
-      environment = 'staging'
-    else
-      environment = params[:environment] || params[:env]
-    end
-
+  def fetch_env_vars(environment)
     APPLICATION_ENVIRONMENT_VARIABLES[environment]
   end
 
   # :nodoc:
   module ClassMethods
     def change_worker_env!(env)
-      env_hash = APPLICATION_ENVIRONMENT_VARIABLES[env]
-      self.site = env_hash['WORKER_HOST']
-      self.user = env_hash['WORKER_KEY']
+      self.site = APPLICATION_ENVIRONMENT_VARIABLES[env]['WORKER_HOST']
+      self.user = APPLICATION_ENVIRONMENT_VARIABLES[env]['WORKER_KEY']
     end
   end
 end

--- a/app/models/concerns/environment_helpers.rb
+++ b/app/models/concerns/environment_helpers.rb
@@ -21,7 +21,7 @@ module EnvironmentHelpers
   end
 
   def set_worker_environment_for(klass, environment = nil)
-    env = environment || params[:environment]
+    env = environment || params[:environment] || APPLICATION_ENVS.first
     env_vars = fetch_env_vars(env)
 
     klass.site = env_vars['WORKER_HOST']

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -21,10 +21,8 @@ class Partner
   end
 
   def update_apis
-    APPLICATION_ENVS.each do |environment|
-      env = APPLICATION_ENVIRONMENT_VARIABLES[environment]
-
-      RestClient.post("#{env['API_HOST']}/harvester/partners", { partner: self.attributes, api_key: env['HARVESTER_API_KEY'] })
+    APPLICATION_ENVS.each do |env|
+      Api::Partner.post(env, { partner: self.attributes })
     end
   end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -26,9 +26,8 @@ class Source
   private
     def update_apis
       partner.update_apis
-      APPLICATION_ENVS.each do |environment|
-        env = APPLICATION_ENVIRONMENT_VARIABLES[environment]
-        RestClient.post("#{env['API_HOST']}/harvester/partners/#{self.partner.id}/sources", { source: self.attributes, api_key: env['HARVESTER_API_KEY'] })
+      APPLICATION_ENVS.each do |env|
+        Api::PartnerSources.post(env, self.partner.id, { source: self.attributes })
       end
     end
 

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -6,5 +6,5 @@
              method: :patch,
              html: { id: "edit-user-form-#{@user['id']}" } do |f| %>
   <input type='text' name='max_requests' value="<%= @user['max_requests'] %>" />
-  <%= f.submit %>
+  <%= f.submit class: 'button' %>
 <% end %>

--- a/config/application.yml.uat
+++ b/config/application.yml.uat
@@ -12,11 +12,6 @@
 # and a Worker running on localhost:3002.
 # Running the Manager allows you to harvest in production environment.
 
-
-uat:
-  OTP_SECRET_KEY:    <%= ENV['OTP_SECRET_KEY'] %>
-  MFA_ENABLED:       <%= ENV['MFA_ENABLED'] %>
-
 staging:
   WORKER_HOST:       <%= ENV['WORKER_HOST'] %>
   WORKER_KEY:        <%= ENV['WORKER_KEY'] %>

--- a/spec/api/request_spec.rb
+++ b/spec/api/request_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::Request do
+  describe '#initialize' do
+    it 'sets the url depending on the env' do
+      request = described_class.new('/test', 'staging')
+      expect(request.url).to include(APPLICATION_ENVIRONMENT_VARIABLES['staging']['API_HOST'])
+
+      request = described_class.new('/test', 'test')
+      expect(request.url).to include(APPLICATION_ENVIRONMENT_VARIABLES['test']['API_HOST'])
+    end
+
+    it 'appends .json to the path' do
+      request = described_class.new('/test', 'staging')
+      expect(request.url).to end_with('/test.json')
+    end
+
+    it 'stores the token correspond to the right env' do
+      request = described_class.new('/test', 'staging')
+      expect(request.token).to include(APPLICATION_ENVIRONMENT_VARIABLES['staging']['HARVESTER_API_KEY'])
+
+      request = described_class.new('/test', 'test')
+      expect(request.token).to include(APPLICATION_ENVIRONMENT_VARIABLES['test']['HARVESTER_API_KEY'])
+    end
+
+    it 'stores the params ready to be used by RestClient if present' do
+      request = described_class.new('/test', 'staging', { param: :value })
+      expect(request.params).to eq(params: { param: :value })
+    end
+
+    it 'stores the params as empty hash if not present' do
+      request = described_class.new('/test', 'staging')
+      expect(request.params).to eq({})
+    end
+  end
+
+  %i[get post put patch delete].each do |method|
+    describe "##{method}" do
+      it "only calls execute with the #{method} method" do
+        request = described_class.new('/test', 'staging')
+        expect(request).to receive(:execute).with(method)
+        request.send(method)
+      end
+    end
+  end
+
+  describe '#execute' do
+    it 'sends the right method' do
+      request = described_class.new('/test', 'staging')
+      expect(RestClient::Request).to receive(:execute).with(hash_including(method: :get))
+      request.get
+
+      request = described_class.new('/test', 'staging')
+      expect(RestClient::Request).to receive(:execute).with(hash_including(method: :put))
+      request.put
+    end
+
+    it 'sends to the set url' do
+      request = described_class.new('/test', 'staging')
+      expect(RestClient::Request).to receive(:execute).with(hash_including(url: request.url))
+      request.get
+    end
+
+    it 'sends the Authentication-Token header' do
+      request = described_class.new('/test', 'staging')
+      expect(RestClient::Request).to receive(:execute).with(hash_including(
+        headers: { 'Authentication-Token': request.token }
+      ))
+      request.get
+    end
+  end
+end

--- a/spec/controllers/collection_records_controller_spec.rb
+++ b/spec/controllers/collection_records_controller_spec.rb
@@ -9,30 +9,30 @@ RSpec.describe CollectionRecordsController do
 
   describe 'GET #index' do
     it 'should be successful' do
-      expect(RestClient).to receive(:get).with("#{ENV['API_HOST']}/harvester/records/.json", params: { api_key: ENV['HARVESTER_API_KEY'] })
+      expect(Api::Record).to_not receive(:get)
       get :index, params: { environment: 'development' }
       expect(response).to be_successful
     end
 
     it 'should search for a record' do
-      expect(RestClient).to receive(:get).with("#{ENV['API_HOST']}/harvester/records/abc123.json", params: { api_key: ENV['HARVESTER_API_KEY'] })
+      expect(Api::Record).to receive(:get).with('development', 'abc123')
       get :index, params: { environment: 'development', id: 'abc123' }
     end
 
     it 'should handle RESTClient errors' do
-      allow(RestClient).to receive(:get).and_raise(RestClient::Exception.new)
+      expect(Api::Record).to receive(:get).with('development', 'abc123').and_raise(RestClient::Exception.new)
       get :index, params: { environment: 'development', id: 'abc123' }
     end
   end
 
   describe 'PUT #update' do
     it 'should make a post to the api to change the status to active for the record' do
-      expect(RestClient).to receive(:put).with("#{ENV['API_HOST']}/harvester/records/abc123", { record: { status: 'active' }, api_key: ENV['HARVESTER_API_KEY'] })
+      expect(Api::Record).to receive(:put).with('development', 'abc123', { record: { status: 'active' } })
       put :update, params: { environment: 'development', id: 'abc123', status: 'active' }
     end
 
     it 'should redirect to #index' do
-      allow(RestClient).to receive(:put)
+      expect(Api::Record).to receive(:put)
       put :update, params: { environment: 'development', id: 'abc123', status: 'active', api_key: ENV['HARVESTER_API_KEY'] }
       expect(response).to redirect_to environment_collection_records_path(environment: 'development', id: 'abc123')
     end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -26,14 +26,12 @@ RSpec.describe HomeController do
     context '#set environment' do
       it 'sets the environment to first available environment' do
         get :index
-        expect(controller.params[:environment]).to eq APPLICATION_ENVS.first.to_s
+        expect(assigns(:environment)).to eq APPLICATION_ENVS.first.to_s
       end
 
-      it 'sets the environment to production and cache the environment' do
+      it 'sets the environment to parameter' do
         get :index, params: { environment: 'production' }
-        expect(controller.params[:environment]).to eq 'production'
-        get :index
-        expect(controller.params[:environment]).to eq 'production'
+        expect(assigns(:environment)).to eq 'production'
       end
     end
 

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -134,5 +134,4 @@ RSpec.describe SourcesController do
       end
     end
   end
-
 end

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -128,10 +128,11 @@ RSpec.describe SourcesController do
 
     describe 'GET reindex' do
       it 'calls reindex on api' do
-        expect(RestClient).to receive(:get).with("#{ENV['API_HOST']}/harvester/sources/#{source.id}/reindex", params: { date: '2013-09-12T01:49:51.067Z', api_key: ENV['HARVESTER_API_KEY'] })
-
-        get :reindex, params: { id: source.to_param, env: 'test', date: '2013-09-12T01:49:51.067Z', format: :js }
+        source = Source.create! valid_attributes
+        expect(Api::Source).to receive(:reindex).with('test', source.id, { date: '2013-09-12T01:49:51.067Z' })
+        get :reindex, params: { id: source.to_param, environment: 'test', date: '2013-09-12T01:49:51.067Z', format: :js }
       end
     end
   end
+
 end

--- a/spec/controllers/suppress_collections_controller_spec.rb
+++ b/spec/controllers/suppress_collections_controller_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe SuppressCollectionsController do
 
   describe "GET 'index'" do
     it 'should call the harvest sources end point to retrieve last 10 updated sources and suppressed' do
-      expect(RestClient).to receive(:get).with("#{ENV['API_HOST']}/harvester/sources", params: { "source[status]": 'suppressed', api_key: ENV['HARVESTER_API_KEY'] }) { '{}' }
-      expect(RestClient).to receive(:get).with("#{ENV['API_HOST']}/harvester/sources", params: { "source[status]": 'active', limit: 10, order_by: 'status_updated_at', api_key: ENV['HARVESTER_API_KEY'] }) { '{}' }
+      expect(Api::Source).to receive(:index).with('development', { source: { status: :suppressed } }) { '{}' }
+      expect(Api::Source).to receive(:index).with('development', { source: { status: :active }, limit: 10, order_by: :status_updated_at }) { '{}' }
       get :index, params: { environment: 'development' }
       expect(response).to be_successful
     end
@@ -20,18 +20,18 @@ RSpec.describe SuppressCollectionsController do
 
   describe "PUT 'update'" do
     it 'should update the source in the API to active and set status_updated_by' do
-      expect(RestClient).to receive(:put).with("#{ENV['API_HOST']}/harvester/sources/abc123", source: { status: 'active', status_updated_by: 'John Doe' }, api_key: ENV['HARVESTER_API_KEY'])
+      expect(Api::Source).to receive(:put).with('development', 'abc123', source: { status: 'active', status_updated_by: 'John Doe' })
       put :update, params: { id: 'abc123', environment: 'development', status: 'active' }
     end
 
     it 'should redirect to suppress collections url' do
-      allow(RestClient).to receive(:put)
+      allow(Api::Source).to receive(:put)
       put :update, params: { id: 'abc123', environment: 'development', source: { status: 'suppressed' }, api_key: ENV['HARVESTER_API_KEY'] }
       expect(response).to redirect_to environment_suppress_collections_path(environment: 'development')
     end
 
     it 'should handle RestClient errors' do
-      allow(RestClient).to receive(:put).and_raise(RestClient::Exception.new)
+      allow(Api::Source).to receive(:put).and_raise(RestClient::Exception.new)
       put :update, params: { id: 'abc123', environment: 'development', status: 'suppressed', api_key: ENV['HARVESTER_API_KEY'] }
     end
   end

--- a/spec/helpers/environment_helper_spec.rb
+++ b/spec/helpers/environment_helper_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe EnvironmentHelpers do
 
   describe '#fetch_env_vars' do
     it 'returns a hash of the available environment variables' do
-      expect(fetch_env_vars).to have_key('WORKER_HOST')
-      expect(fetch_env_vars).to have_key('HARVESTER_API_KEY')
-      expect(fetch_env_vars).to have_key('API_HOST')
-      expect(fetch_env_vars).to have_key('WORKER_KEY')
+      expect(fetch_env_vars('staging')).to have_key('WORKER_HOST')
+      expect(fetch_env_vars('staging')).to have_key('HARVESTER_API_KEY')
+      expect(fetch_env_vars('staging')).to have_key('API_HOST')
+      expect(fetch_env_vars('staging')).to have_key('WORKER_KEY')
     end
   end
 

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Partner do
   before do
-    allow(RestClient).to receive(:post)
+    allow(Api::Partner).to receive(:post)
   end
 
   describe 'validations' do
@@ -32,11 +32,10 @@ RSpec.describe Partner do
 
     it 'updates each environments' do
       APPLICATION_ENVS.each do |env|
-        env = APPLICATION_ENVIRONMENT_VARIABLES[env]
-        expect(RestClient).to receive(:post).with("#{env['API_HOST']}/harvester/partners", anything)
-
-        partner.update_apis
+        expect(Api::Partner).to receive(:post).with(env, anything)
       end
+
+      partner.update_apis
     end
   end
 end


### PR DESCRIPTION
[API KEY IN HEADER FOR SJ MANAGER: As Sasha, I want Supplejack Manager to use HTTP-header based authentication for making API requests, so that the API keys are kept secret](https://www.pivotaltracker.com/story/show/179971720)

STORY
=====

**Acceptance Criteria**
- Supplejack Manager passes API Key in the HTTP Header, and not in the URL
