### PR TITLE
INVESTIGATE SEARCHING PARSER CONTENT WITH MONGO: As Dan, I want to understand if Mongo would be feasible for searching within parser content, so that we can build the right thing

### DIFF
--- a/app/controllers/parsers_controller.rb
+++ b/app/controllers/parsers_controller.rb
@@ -111,11 +111,12 @@ class ParsersController < ApplicationController
     def datatable_params
       sorted_by_column = params[:order]['0'][:column]
       {
-        search:    params[:search][:value],
-        start:     params[:start].to_i,
-        per_page:  params[:length].to_i,
-        order_by:  params[:columns][sorted_by_column][:data],
-        direction: params[:order]['0'][:dir],
+        search:      params[:search][:value],
+        search_type: params[:search][:type],
+        start:       params[:start].to_i,
+        per_page:    params[:length].to_i,
+        order_by:    params[:columns][sorted_by_column][:data],
+        direction:   params[:order]['0'][:dir],
       }
     end
 end

--- a/app/javascript/src/parsers.js
+++ b/app/javascript/src/parsers.js
@@ -101,10 +101,15 @@ $(function() {
     update_source_from_contributor_value($stored_sources)
   });
 
-  return $('#parsers').dataTable({
+  var table = $('#parsers').dataTable({
     "processing": true,
     "serverSide": true,
-    "ajax": "/parsers/datatable",
+    "ajax": {
+      "url": "/parsers/datatable",
+      "data": function(data) {
+        data.search.type = $('input[name="type"]:checked').val();
+      }
+    },
     "aaSorting": [[4, 'desc']],
     "columns": [
       {
@@ -132,6 +137,14 @@ $(function() {
       { "data": "last_editor" },
       { "data": "data_type" },
     ]
+  });
+
+  $('input[value="quick_search"]').on('click', function() {
+    table.fnDraw();
+  });
+
+  $('input[value="content_search"]').on('click', function() {
+    table.fnDraw();
   });
 });
 

--- a/app/javascript/src/parsers.js
+++ b/app/javascript/src/parsers.js
@@ -139,6 +139,27 @@ $(function() {
     ]
   });
 
+  // remove the empty div.cell.small-6
+  table.parents('.dataTables_wrapper').find('.small-6:first').remove();
+  // make the other column wider
+  var div = table.parents('.dataTables_wrapper').find('.small-6:first')
+  div.removeClass('small-6');
+  div.addClass('small-12');
+
+  // Add the radios
+  var searchInput = table.parents('.dataTables_wrapper').find('input[type=search]').parent('label');
+  var radios = $(`
+    <label>
+      <input type="radio" name="type" value="quick_search" checked>
+      Quick search
+    </label>
+    <label>
+      <input type="radio" name="type" value="content_search">
+      Search within parser content
+    </label>
+    `);
+  searchInput.after(radios);
+
   $('input[value="quick_search"]').on('click', function() {
     table.fnDraw();
   });

--- a/app/javascript/stylesheets/blocks/_parsers.scss
+++ b/app/javascript/stylesheets/blocks/_parsers.scss
@@ -1,15 +1,14 @@
-
-
 // Place all the styles related to the parsers controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 // parsers/index.html.erb
-label.new-right {
-  float: right;
-  margin-left: 20px;
-  position: relative;
-  z-index: 100;
+#parsers-index {
+  label {
+    display: inline-block;
+    margin-left: 20px;
+    float: none;
+  }
 }
 
 // others

--- a/app/javascript/stylesheets/blocks/_parsers.scss
+++ b/app/javascript/stylesheets/blocks/_parsers.scss
@@ -4,6 +4,16 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
+// parsers/index.html.erb
+label.new-right {
+  float: right;
+  margin-left: 20px;
+  position: relative;
+  z-index: 100;
+}
+
+// others
+
 #preview-modal {
   padding-top: 16px;
   height: 98vh;

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -85,7 +85,17 @@ class Parser
     return query.attribute_search(params[:search]) if params[:search_type] == 'quick_search'
     return query if params[:search].empty?
 
-    query.where('versions.content' => %r{#{::Regexp.escape(params[:search])}})
+    query.content_search(params[:search])
+  end
+
+  def self.content_search(text)
+    regex = %r{#{::Regexp.escape(text)}}
+    where(
+      '$or' => [
+        { 'content' =>          regex },
+        { 'versions.content' => regex }
+      ]
+    )
   end
 
   def self.attribute_search(words)

--- a/app/models/parser.rb
+++ b/app/models/parser.rb
@@ -85,7 +85,7 @@ class Parser
     return query.attribute_search(params[:search]) if params[:search_type] == 'quick_search'
     return query if params[:search].empty?
 
-    query.where('versions.content' => %r{#{params[:search]}})
+    query.where('versions.content' => %r{#{::Regexp.escape(params[:search])}})
   end
 
   def self.attribute_search(words)

--- a/app/views/parsers/index.html.erb
+++ b/app/views/parsers/index.html.erb
@@ -4,7 +4,7 @@
 
 <label class="middle new-right">
   <input type="radio" name="type" value="content_search">
-  Search withing parser content
+  Search within parser content
 </label>
 <label class="middle new-right">
   <input type="radio" name="type" value="quick_search" checked>

--- a/app/views/parsers/index.html.erb
+++ b/app/views/parsers/index.html.erb
@@ -1,14 +1,16 @@
 <h1><%= t('parsers.label') %></h1>
+
 <%= link_to t('parsers.create'), new_parser_path, class: "button new-right #{can_show_button(:create, Parser)}" %>
 
-<label>
-  <input type="radio" name="type" value="quick_search">
-  Quick search
-</label>
-<label>
-  <input type="radio" name="type" value="content_search" checked>
+<label class="middle new-right">
+  <input type="radio" name="type" value="content_search">
   Search withing parser content
 </label>
+<label class="middle new-right">
+  <input type="radio" name="type" value="quick_search" checked>
+  Quick search
+</label>
+
 <table id="parsers" class="twelve">
   <thead>
     <tr>

--- a/app/views/parsers/index.html.erb
+++ b/app/views/parsers/index.html.erb
@@ -1,26 +1,19 @@
-<h1><%= t('parsers.label') %></h1>
+<div id="parsers-index">
+  <h1><%= t('parsers.label') %></h1>
 
-<%= link_to t('parsers.create'), new_parser_path, class: "button new-right #{can_show_button(:create, Parser)}" %>
+  <%= link_to t('parsers.create'), new_parser_path, class: "button new-right #{can_show_button(:create, Parser)}" %>
 
-<label class="middle new-right">
-  <input type="radio" name="type" value="content_search">
-  Search within parser content
-</label>
-<label class="middle new-right">
-  <input type="radio" name="type" value="quick_search" checked>
-  Quick search
-</label>
-
-<table id="parsers" class="twelve">
-  <thead>
-    <tr>
-      <th>Harvest Name</th>
-      <th>Data Format</th>
-      <th>Partner</th>
-      <th>Source ID</th>
-      <th>Last Update</th>
-      <th>Last Edited By</th>
-      <th>Parser Type</th>
-    </tr>
-  </thead>
-</table>
+  <table id="parsers" class="twelve">
+    <thead>
+      <tr>
+        <th>Harvest Name</th>
+        <th>Data Format</th>
+        <th>Partner</th>
+        <th>Source ID</th>
+        <th>Last Update</th>
+        <th>Last Edited By</th>
+        <th>Parser Type</th>
+      </tr>
+    </thead>
+  </table>
+</div>

--- a/app/views/parsers/index.html.erb
+++ b/app/views/parsers/index.html.erb
@@ -1,6 +1,14 @@
 <h1><%= t('parsers.label') %></h1>
 <%= link_to t('parsers.create'), new_parser_path, class: "button new-right #{can_show_button(:create, Parser)}" %>
 
+<label>
+  <input type="radio" name="type" value="quick_search">
+  Quick search
+</label>
+<label>
+  <input type="radio" name="type" value="content_search" checked>
+  Search withing parser content
+</label>
 <table id="parsers" class="twelve">
   <thead>
     <tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   resources :parsers do
     get :allow_flush, on: :member
-    get 'datatable', on: :collection, constraints: { format: :json }
+    get :datatable, on: :collection, constraints: { format: :json }
     resources :previewers, only: [:create]
     resources :parser_versions, path: 'versions', only: [:show, :update] do
       get :current, on: :collection

--- a/spec/factories/parsers.rb
+++ b/spec/factories/parsers.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :parser do
     name      { Faker::Name.first_name }
     strategy  { 'xml' }
-    content   { 'class NZMuseums < SupplejackCommon::Xml::Base; end' }
+    content   { "class NZMuseums < SupplejackCommon::Xml::Base; %r{#{Faker::Name.last_name}}'; end" }
     data_type { 'record' }
     message { 'test message' }
     source

--- a/spec/features/parsers/search_parsers_spec.rb
+++ b/spec/features/parsers/search_parsers_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Manage parser', type: :feature, js: true do
+  let(:parsers_page) { ParsersPage.new }
+  let(:admin_user) { create(:user, :admin) }
+  let!(:parsers) do
+    allow_any_instance_of(Source).to receive(:update_apis)
+    allow_any_instance_of(Partner).to receive(:update_apis)
+    allow(LinkCheckRule).to receive(:create)
+    create_list(:parser, 3)
+  end
+
+
+  before do
+    login_as(admin_user, scope: :user)
+    parsers_page.load
+  end
+
+  scenario 'Do a quick search by default' do
+    expect(parsers_page.selected_search['value']).to eq 'quick_search'
+  end
+
+  scenario 'Searching a parser name' do
+    fill_in 'Search:', with: Parser.first.name
+
+    # check that only 1 parser is found
+    find('tbody tr:only-child') # forces capybara to wait for the async request
+    expect(parsers_page.table_rows.count).to eq 1
+
+    # check that the right parser is found
+    expect(parsers_page.parser_table.find('tbody > tr > td:first-child').text).to eq Parser.first.name
+  end
+
+  scenario 'Searching a parser content' do
+    # select the content search and search for a specific word from the first parser content
+    parsers_page.content_search_radio.click
+    random_last_name_from_faker = Parser.first.content.match(/%r{(.*)}/)[1]
+    fill_in 'Search:', with: random_last_name_from_faker
+
+    # check that only 1 parser is found
+    find('tbody tr:only-child') # forces capybara to wait for the async request
+    expect(parsers_page.table_rows.count).to eq 1
+
+    # check that the right parser is found
+    expect(parsers_page.parser_table.find('tbody > tr > td:first-child').text).to eq Parser.first.name
+  end
+end

--- a/spec/page_objects/parser/parsers_page.rb
+++ b/spec/page_objects/parser/parsers_page.rb
@@ -4,4 +4,9 @@ class ParsersPage < ApplicationPage
   set_url '/parsers'
 
   element :parser_table, '#parsers'
+  elements :table_rows, '#parsers tbody tr'
+
+  element :selected_search, 'input[type="radio"]:checked'
+  element :quick_search_radio, 'input[value="quick_search"]'
+  element :content_search_radio, 'input[value="content_search"]'
 end


### PR DESCRIPTION
[INVESTIGATE SEARCHING PARSER CONTENT WITH MONGO: As Dan, I want to understand if Mongo would be feasible for searching within parser content, so that we can build the right thing](https://www.pivotaltracker.com/story/show/180339107)

STORY
=====

**Acceptance Criteria** 
- Identify using Mongo to enable searching for code within parser content
- Parser search results page:
 - (MVP / short term) return top level link to parser
 - (Ideally) return link to most recent version with a match
 - (a later iteration) provide all options of which versions have matches

**Risks** 
- There are a lot of versions (250) on some big (1200+ line) parsers 
 - Search could be slow? 
 - Relevancy could be dumb due to many versions getting more hits? 
- Introducing reliance/dependency between manager and the API/solr/Mongo

**Notes on Mongo**
- Seems like we will want to [exclude certain fields](https://docs.mongodb.com/compass/current/query/project/) from the response to avoid the front end handling all the massive data in the body of the parser (and the versions). 

**Notes on options other than Mongo** 
- Could try using a mongo query directly (Andy G approved), or indexing into Solr, or ES? or github, blockchain, meta?
- Github option would require some considerable refactoring but could bring about other benefits.
- Back in the wild west days Dan used to run queries like this in mongo `db.getCollection('parsers').find({content: /Net::HTTP/})`
- Maybe check the size of the parser collection in mongo and considering performance of direct querying 
- Original implementation story https://www.pivotaltracker.com/story/show/180076730

**indexing options**
- index each version individually - to be returned as separate results
 - results need deduping, keeping only most recent version
 - problem: versions are nested under each parser and dont really know anything about the parent
- index each parser once - with all versions
 - easier in short term
 - eventually could we build in ability to link to most recent version with a match?