### PR TITLE
UPGRADE ELASTIC STACK: As Dan I want the Elastic Stack kept up to date so that it remains secure and effective

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elastic-apm (4.4.0)
+    elastic-apm (4.5.0)
       concurrent-ruby (~> 1.0)
       http (>= 3.0)
     encryptor (3.0.0)
@@ -220,7 +220,7 @@ GEM
     faraday-rack (1.0.0)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    ffi (1.15.4)
+    ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake


### PR DESCRIPTION
**Acceptance Criteria**
- ElasticStack upgraded
- Elastic Search CVE addressed
- Elastic APM gem is upgraded to stay in sync with ElasticSearch

**Risks**
- 


**Notes**

- Richard says:
>ClamAV has picked up on that JLog CVE inside of our ElasticSearch images. It looks like ElasticSearch have released a patch change to fix this in 7.16.1
EKS is on 7,16.0 and Kops is on 7.14.1 
Iv checked with Andy and Elastic have said that the vulnerability can't be exploited in their application, but have released this fix as a precaution
