### PR TITLE
FIX: SOURCE_ID IN PARSER META FORM

### DIFF
--- a/app/views/parsers/edit_meta.html.erb
+++ b/app/views/parsers/edit_meta.html.erb
@@ -6,7 +6,7 @@
     <%= f.label :partner, 'Contributor' %>
     <%= f.select :partner, @partners.sort(name: 1).map { |p| [p.name, p.name] }, selected: @parser.partner.name %>
 
-    <%= f.label :source, 'Data source' %>
+    <%= f.label :source, 'Data source', data: { 'current_source_id': @parser.source_id } %>
     <%= f.grouped_collection_select(:source_id, @partners, :sources, :name, :id, :source_id) %>
 
     <%= link_to 'Cancel', edit_parser_path(@parser), class: 'button secondary' %>


### PR DESCRIPTION
The right source_id not selected on loading the form. This code was missed on the last [change](https://github.com/DigitalNZ/supplejack_manager/blob/fc13bd8c7e1324fbbbacbb74b9a645b6c46ee563/app/views/parsers/_parser.html.erb#L200) we made here.