### PR TITLE
CLEAN UP OLD PREVIEWS

### DIFF
--- a/lib/tasks/previews.rake
+++ b/lib/tasks/previews.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :previews do
+  desc 'Deletes previews created'
+  task purge: :environment do
+    Preview.where(:created_at.lte => 7.days.ago).delete_all
+  end
+end


### PR DESCRIPTION
**Acceptance Criteria**
- Old previews are deleted from the worker/manager.
- Create a cleanup task to do this daily/weekly .