### PR TITLE
SJ PREVIEW JOBS STOP RELIABLY: As Tim, I want any preview jobs/processes to be stopped when the preview window closes, so that long running preview processes do not continue silently up to no good in the background.

### DIFF
--- a/app/channels/preview_channel.rb
+++ b/app/channels/preview_channel.rb
@@ -9,6 +9,8 @@ class PreviewChannel < ApplicationCable::Channel
   end
 
   def unsubscribed
-    Preview.find(params[:id]).destroy
+    preview = Preview.find(params[:id])
+    preview.stop_preview_worker!
+    preview.destroy
   end
 end

--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -32,7 +32,8 @@ class PreviewsController < ApplicationController
       environment: 'preview',
       index: params[:index].to_i,
       limit: params[:index].to_i + 1,
-      user_id: current_user.id
+      user_id: current_user.id,
+      preview_id: @preview.id
     )
     @preview.start_preview_worker(job.id)
 

--- a/app/models/harvest_job.rb
+++ b/app/models/harvest_job.rb
@@ -25,6 +25,7 @@ class HarvestJob < AbstractJob
     attribute :posted_records_count,  :integer
     attribute :limit,                 :integer
     attribute :retried_records_count, :integer
+    attribute :preview_id,            :string
   end
 
   def resumable?

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -26,6 +26,12 @@ class Preview
     RestClient.post(preview_url, { preview_id: id, job_id: job_id })
   end
 
+  def stop_preview_worker!
+    preview_url = "#{ENV['PREVIEW_WORKER_HOST'] || ENV['WORKER_HOST']}/previews"
+
+    RestClient.delete("#{preview_url}/#{id}")
+  end
+
   def harvest_failure?
     !!harvest_failure
   end

--- a/spec/models/preview_spec.rb
+++ b/spec/models/preview_spec.rb
@@ -106,5 +106,12 @@ RSpec.describe Preview do
       expect(preview.field_errors_json).to be nil
     end
   end
+
+  describe '#stop_preview_worker!' do
+    it 'tells the worker to stop the preview worker' do
+      expect(RestClient).to receive(:delete).with("#{ENV['WORKER_HOST']}/previews/#{preview.id}")
+      preview.stop_preview_worker!
+    end
+  end
 end
 # Final newline missing.


### PR DESCRIPTION
**Acceptance Criteria**
- Closing the preview pop up window reliably/safely stops all related preview processes

**Risks**
- ?

**Notes**
- Silent processes sometimes continue running and cant be stopped by harvest operators, sometimes pinging other peoples servers in a ddos'y way
- For example if you make a mistake in the rejection criteria, and it rejects every record in a long paginated list, it will continue paging through even after you realise and close the preview.
- Ideally the same think happens when you stop a running harvest job. Lets say the harvest is malfunctioning and you want to stop it to fix the parser and re-run, you dont want the old job to continue running in the background (perhaps in another story) 
- When you close the harvest modal the harvest is expected to keep running 

**Tests**
- Dan could make a test parser that pages through our API.
