### PR TITLE
SJ IMPROVE ENRICHMENT PREVIEW PROCESS: As Tim I want enrichment preview process improved, so that developing and troubleshooting enrichments is easy and reliable with useful feedback

### DIFF
--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -68,6 +68,7 @@ class PreviewsController < ApplicationController
         :validation_errors,
         :harvest_failure,
         :harvest_job_errors,
+        :enrichment_failures,
         :format,
         harvest_job: [
           :parser_code,

--- a/app/javascript/channels/preview_channel.js
+++ b/app/javascript/channels/preview_channel.js
@@ -48,6 +48,10 @@ const PreviewChannel = (id) => {
       console.log('PreviewChannel received')
       $('#preview-area-spinner').hide();
       $('#status').html(data.status);
+      $('#preview-status .details__content').html('');
+      $.each(data.logs, function(_, log) {
+        $('#preview-status .details__content').append(`${log} <br />`)
+      })
 
       updateResult('#harvested-attributes', JSON.stringify(JSON.parse(data.harvested_attributes), null, 2));
 
@@ -96,16 +100,6 @@ const PreviewChannel = (id) => {
         $.each(failure.backtrace, function(key, value) {
           $('#harvest-failure .details__content').append(value + "<br />");
         });
-      }
-
-      // Status Log
-
-      if(data.status) {
-        $('#status-log').append("<p>" + data.status + "</p>");
-      }
-
-      if(data.status_log) {
-        $('#status-log').append("<p>" + data.status_log + "</p>");
       }
 
       if(data.status == 'finished' && data.raw_data == null) {

--- a/app/javascript/channels/preview_channel.js
+++ b/app/javascript/channels/preview_channel.js
@@ -90,11 +90,11 @@ const PreviewChannel = (id) => {
         var failure = JSON.parse(data.harvest_failure);
 
         $('#status').html("Harvest Failed");
-        $('#harvest-failure h6').html(failure.exception_class);
-        $('#harvest-failure p').html(failure.message);
+        $('#harvest-failure').removeClass('hide');
+        $('#harvest-failure h4').html(`Harvest failure: ${failure.exception_class} "${failure.message}"`);
 
         $.each(failure.backtrace, function(key, value) {
-          $('#harvest-failure ul').append("<li>" + value + "</li>");
+          $('#harvest-failure .details__content').append(value + "<br />");
         });
       }
 

--- a/app/javascript/channels/preview_channel.js
+++ b/app/javascript/channels/preview_channel.js
@@ -23,6 +23,7 @@ const PreviewChannel = (id) => {
         } catch(_) {
           object = currentPreview[attribute];
         }
+        object = object == 'null' ? '' : object;
         updateResult(`#${event.target.dataset.tabsTarget}`, object);
       }, 1)
     });

--- a/app/javascript/channels/preview_channel.js
+++ b/app/javascript/channels/preview_channel.js
@@ -99,10 +99,24 @@ const PreviewChannel = (id) => {
         $('#harvest-failure').removeClass('hide');
         $('#harvest-failure h4').html(`Harvest failure: ${failure.exception_class} "${failure.message}"`);
 
-        $.each(failure.backtrace, function(key, value) {
-          $('#harvest-failure .details__content').append(value + "<br />");
+        $.each(failure.backtrace, function(_, line) {
+          $('#harvest-failure .details__content').append(line + "<br />");
         });
       }
+
+      if(data.enrichment_failures) {
+        $('#enrichment-failures').html('')
+        const failures = JSON.parse(data.enrichment_failures)
+        $.each(failures, function(_, failure) {
+          $('#enrichment-failures').append(`
+            <details class="details details--warning">
+              <summary class="details__summary"><h4>Enrichment "${failure.enrichment_name}" failed: ${failure.exception_class} "${failure.message}"</h4></summary>
+              <div class="details__content">${failure.backtrace.join('<br />')}</div>
+            </details>
+          `)
+        });
+      }
+
 
       if(data.status == 'finished' && data.raw_data == null) {
         $('h4.not-found').show();

--- a/app/javascript/channels/preview_channel.js
+++ b/app/javascript/channels/preview_channel.js
@@ -53,7 +53,8 @@ const PreviewChannel = (id) => {
         $('#preview-status .details__content').append(`${log} <br />`)
       })
 
-      updateResult('#harvested-attributes', JSON.stringify(JSON.parse(data.harvested_attributes), null, 2));
+      // fires the code mirror rendering
+      $('#preview-tabs li.is-active a')[0].click();
 
       if(data.field_errors != null && data.field_errors != '{}') {
         $('#status').html("Field Errors");

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -8,8 +8,12 @@
 // foundation related
 @import 'foundation/foundation_and_overrides';
 
+// custom mixins
+@import 'mixins/bem';
+
 // custom forms
 @import 'blocks/base';
+@import 'blocks/details';
 @import 'blocks/forms';
 @import 'blocks/top_nav';
 @import 'blocks/parsers';

--- a/app/javascript/stylesheets/blocks/_details.scss
+++ b/app/javascript/stylesheets/blocks/_details.scss
@@ -10,6 +10,8 @@
 
   @each $name, $color in $foundation-palette {
     @include modifier(#{$name}) {
+      margin: 1rem 0;
+
       .details__summary {
         background-color: scale-color($color, $lightness: $callout-background-fade);
         padding: .5rem 1rem;

--- a/app/javascript/stylesheets/blocks/_details.scss
+++ b/app/javascript/stylesheets/blocks/_details.scss
@@ -1,0 +1,24 @@
+.details {
+  @include element('summary') {
+    // trick to avoid the text going under the arrow
+    & > * {
+      display: inline;
+    }
+
+    cursor: pointer;
+  }
+
+  @each $name, $color in $foundation-palette {
+    @include modifier(#{$name}) {
+      .details__summary {
+        background-color: scale-color($color, $lightness: $callout-background-fade);
+        padding: .5rem 1rem;
+      }
+
+      .details__content {
+        border: 2px solid scale-color($color, $lightness: $callout-background-fade);
+        padding: 1rem;
+      }
+    }
+  }
+}

--- a/app/javascript/stylesheets/blocks/_parsers.scss
+++ b/app/javascript/stylesheets/blocks/_parsers.scss
@@ -16,6 +16,7 @@
 #preview-modal {
   padding-top: 16px;
   height: 98vh;
+  width: 98%;
 }
 
 .parser-tag {

--- a/app/javascript/stylesheets/blocks/_previewers.scss
+++ b/app/javascript/stylesheets/blocks/_previewers.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Previewers controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/javascript/stylesheets/blocks/_previews.scss
+++ b/app/javascript/stylesheets/blocks/_previews.scss
@@ -18,3 +18,7 @@
   max-height: 75vh;
   overflow: scroll;
 }
+
+#harvest-failure {
+  margin-top: 1rem;
+}

--- a/app/javascript/stylesheets/blocks/_previews.scss
+++ b/app/javascript/stylesheets/blocks/_previews.scss
@@ -18,7 +18,3 @@
   max-height: 75vh;
   overflow: scroll;
 }
-
-#harvest-failure {
-  margin-top: 1rem;
-}

--- a/app/javascript/stylesheets/mixins/_bem.scss
+++ b/app/javascript/stylesheets/mixins/_bem.scss
@@ -1,0 +1,13 @@
+/// Block Element
+@mixin element($element) {
+  &__#{$element} {
+    @content;
+  }
+}
+
+/// Block Modifier
+@mixin modifier($modifier) {
+  &--#{$modifier} {
+    @content;
+  }
+}

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -20,6 +20,7 @@ class Preview
   field :field_errors,         type: String
   field :validation_errors,    type: String
   field :harvest_failure,      type: String
+  field :enrichment_failures,  type: String
   field :harvest_job_errors,   type: String
   field :format,               type: String
 

--- a/app/models/preview.rb
+++ b/app/models/preview.rb
@@ -5,6 +5,8 @@ class Preview
   include Mongoid::Document
   include Mongoid::Timestamps
 
+  before_save :append_logs
+
   field :parser_code,          type: String
   field :parser_id,            type: String
   field :index,                type: Integer
@@ -13,6 +15,7 @@ class Preview
   field :harvested_attributes, type: String
   field :api_record,           type: String
   field :status,               type: String
+  field :logs,                 type: Array, default: []
   field :deletable,            type: Boolean
   field :field_errors,         type: String
   field :validation_errors,    type: String
@@ -24,6 +27,10 @@ class Preview
     preview_url = "#{ENV['PREVIEW_WORKER_HOST'] || ENV['WORKER_HOST']}/previews"
 
     RestClient.post(preview_url, { preview_id: id, job_id: job_id })
+  end
+
+  def append_logs
+    logs << status if status_changed? && status.present?
   end
 
   def harvest_failure?

--- a/app/views/previews/_previewer.erb
+++ b/app/views/previews/_previewer.erb
@@ -12,7 +12,12 @@
 
 <div class="grid-x" id="preview-<%=@preview.id%>">
   <div class="medium-12 cell">
-    <p><strong>Status: </strong><span id="status">Initialising preview record...</span></p>
+    <details class="details details--primary" id="preview-status">
+      <summary class="details__summary"><strong>Status: </strong><span id="status">Initialising preview record...</span></summary>
+      <div class="details__content">
+        <%= @preview.logs.join("<br />") %>
+      </div>
+    </details>
 
     <div id="record-to-delete" class="hidden">
       <p></strong>This record is marked for deletion.</em></p>

--- a/app/views/previews/_previewer.erb
+++ b/app/views/previews/_previewer.erb
@@ -12,61 +12,61 @@
 
 <div class="grid-x" id="preview-<%=@preview.id%>">
   <div class="medium-12 cell">
-      <p><strong>Status: </strong><span id="status">Initialising preview record...</span></p>
+    <p><strong>Status: </strong><span id="status">Initialising preview record...</span></p>
 
-      <div id="record-to-delete" class="hidden">
-        <p></strong>This record is marked for deletion.</em></p>
+    <div id="record-to-delete" class="hidden">
+      <p></strong>This record is marked for deletion.</em></p>
+    </div>
+
+    <div id="field-errors" class="hidden">
+      <h4>Field Errors</h4>
+      <textarea class="code-editor-multiple read-only"></textarea>
+    </div>
+
+    <div id="harvest-errors" class="hidden">
+      <h4>Harvest Errors</h4>
+      <p></p>
+    </div>
+
+    <div id="validation-errors" class="hidden">
+      <h4>Validation Errors</h4>
+      <ul class="indented"></ul>
+    </div>
+
+    <ul class='tabs' data-tabs id='preview-tabs'>
+      <li class='tabs-title'>
+        <a data-tabs-target='source-data'>Source Data<span class="small-spinner"></span></a>
+      </li>
+      <li class='tabs-title is-active' aria-selected='true'>
+        <a data-tabs-target='harvested-attributes'>Harvested Attributes<span class="small-spinner"></span></a>
+      </li>
+      <li class='tabs-title'>
+        <a data-tabs-target="api-record">API <%= @parser.data_type.capitalize rescue 'Record' %><span class="small-spinner"></span></a>
+      </li>
+      <div class="align-right next-previous">
+        <%= link_to_previous @parser.id, params[:index], params[:environment], params[:review], class: "records-preview-button" %> - Preview Record -
+        <%= link_to_next @parser.id, params[:index], params[:environment], params[:review], class: "records-preview-button" %>
+      </div>
+    </ul>
+
+    <div class="tabs-content" data-tabs-content='preview-tabs'>
+      <div class='tabs-panel' id="source-data">
+        <textarea id="record-raw-data" class='code-editor-multiple'></textarea>
       </div>
 
-      <div id="field-errors" class="hidden">
-        <h4>Field Errors</h4>
-        <textarea class="code-editor-multiple read-only"></textarea>
+      <div class="tabs-panel is-active" id="harvested-attributes">
+        <textarea id="harvest-attributes" class='code-editor-multiple'></textarea>
       </div>
 
-      <div id="harvest-errors" class="hidden">
-        <h4>Harvest Errors</h4>
-        <p></p>
+      <div class='tabs-panel' id="api-record">
+        <textarea id="record-attributes" class='code-editor-multiple'></textarea>
       </div>
+    </div>
 
-      <div id="validation-errors" class="hidden">
-        <h4>Validation Errors</h4>
-        <ul class="indented"></ul>
-      </div>
-
-      <ul class='tabs' data-tabs id='preview-tabs'>
-        <li class='tabs-title'>
-          <a data-tabs-target='source-data'>Source Data<span class="small-spinner"></span></a>
-        </li>
-        <li class='tabs-title is-active' aria-selected='true'>
-          <a data-tabs-target='harvested-attributes'>Harvested Attributes<span class="small-spinner"></span></a>
-        </li>
-        <li class='tabs-title'>
-          <a data-tabs-target="api-record">API <%= @parser.data_type.capitalize rescue 'Record' %><span class="small-spinner"></span></a>
-        </li>
-        <div class="align-right next-previous">
-          <%= link_to_previous @parser.id, params[:index], params[:environment], params[:review], class: "records-preview-button" %> - Preview Record -
-          <%= link_to_next @parser.id, params[:index], params[:environment], params[:review], class: "records-preview-button" %>
-        </div>
-      </ul>
-
-      <div class="tabs-content" data-tabs-content='preview-tabs'>
-        <div class='tabs-panel' id="source-data">
-          <textarea id="record-raw-data" class='code-editor-multiple'></textarea>
-        </div>
-
-        <div class="tabs-panel is-active" id="harvested-attributes">
-          <textarea id="harvest-attributes" class='code-editor-multiple'></textarea>
-        </div>
-
-        <div class='tabs-panel' id="api-record">
-          <textarea id="record-attributes" class='code-editor-multiple'></textarea>
-        </div>
-      </div>
-
-      <details class="details details--warning hide" id="harvest-failure">
-        <summary class="details__summary"><h4></h4></summary>
-        <div class="details__content"></div>
-      </details>
+    <details class="details details--warning hide" id="harvest-failure">
+      <summary class="details__summary"><h4></h4></summary>
+      <div class="details__content"></div>
+    </details>
   </div>
 </div>
 

--- a/app/views/previews/_previewer.erb
+++ b/app/views/previews/_previewer.erb
@@ -19,6 +19,8 @@
       </div>
     </details>
 
+    <div id="enrichment-failures"></div>
+
     <div id="record-to-delete" class="hidden">
       <p></strong>This record is marked for deletion.</em></p>
     </div>

--- a/app/views/previews/_previewer.erb
+++ b/app/views/previews/_previewer.erb
@@ -63,11 +63,10 @@
         </div>
       </div>
 
-      <div id="harvest-failure">
-        <h6></h6>
-        <p></p>
-        <ul class="indented"></ul>
-      </div>
+      <details class="details details--warning hide" id="harvest-failure">
+        <summary class="details__summary"><h4></h4></summary>
+        <div class="details__content"></div>
+      </details>
   </div>
 </div>
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -10,6 +10,8 @@ Rails.application.config.filter_parameters += %i[
   parser_code
   raw_data
   harvested_attributes
+  harvest_failure
+  enrichment_failures
   api_record
   content
 ]

--- a/spec/models/preview_spec.rb
+++ b/spec/models/preview_spec.rb
@@ -106,5 +106,30 @@ RSpec.describe Preview do
       expect(preview.field_errors_json).to be nil
     end
   end
+
+  describe '#append_logs' do
+    it 'logs defaults to []' do
+      expect(Preview.new.logs).to eq []
+    end
+
+    it 'saves the status if non empty' do
+      preview = Preview.create(status: nil)
+      expect(preview.logs).to eq []
+    end
+
+    it 'appends the logs only if the status has changed' do
+      preview = Preview.create(status: 'line_1')
+      expect(preview.logs).to eq ['line_1']
+
+      preview.update(format: 'another_format', status: 'line_1')
+      expect(preview.logs).to eq ['line_1']
+    end
+
+    it 'appends the logs in the right order' do
+      preview = Preview.create(status: 'line_1')
+      preview.update(format: 'another_format', status: 'line_2')
+      preview.update(format: 'another_format', status: 'line_3')
+      expect(preview.logs).to eq ['line_1', 'line_2', 'line_3']
+    end
+  end
 end
-# Final newline missing.


### PR DESCRIPTION
[SJ IMPROVE ENRICHMENT PREVIEW PROCESS: As Tim I want enrichment preview process improved, so that developing and troubleshooting enrichments is easy and reliable with useful feedback](https://www.pivotaltracker.com/story/show/180640850)

STORY
=====

**Acceptance Criteria**
- Enrichment process is captured in preview reliably!
- Failures are captured/presented

**Risks**
- ?

**Notes**
- Following Eddy's story https://www.pivotaltracker.com/story/show/108033670:
>Issues with Enrichment
Enrichment is a background job triggered within a background job. Current enrichment worker is not designed to effectively return any information to a preview, it just starts and ends. This can be fixed but will require adding more functionalities to the existing enrichment worker.
- Enrichments previews should run in the same way with the same level and method of feed back to the user
- Test below fails informatively, rather than silently

**Tests**
- Enrichments fail silently and strangely (in a confusing cached way)
 - Load [this parser version](https://manager.digitalnz.org/parsers/558b3bea297b1fc90f000003/versions/61a533c471cffd0009b2365f)
 - Preview as is, checking the enrichment worked
 - Then make the 2 changes mentioned on line 53
 - Preview again and notice the enrichment will silently fail and show the previous preview result.
