### PR TITLE
REPLACE RENDER_ASYNC WITH HOTWIRE IN MANAGER: As Dan, I want to remove render_async, so that it's easier to maintain

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,6 @@ gem 'oai'
 gem 'puma'
 gem 'rails', '~> 7.0.2'
 gem 'redis', '~> 4.0' # for action_cable in production
-gem 'render_async', '~> 2.1', '>= 2.1.11'
 gem 'rqrcode'
 gem 'server_timing'
 gem 'supplejack_common', github: 'DigitalNZ/supplejack_common', tag: 'v2.10.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,6 @@ GEM
     randexp (0.1.7)
     redis (4.6.0)
     regexp_parser (2.2.1)
-    render_async (2.1.11)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
@@ -564,7 +563,6 @@ DEPENDENCIES
   rails (~> 7.0.2)
   rails-controller-testing
   redis (~> 4.0)
-  render_async (~> 2.1, >= 2.1.11)
   rqrcode
   rspec-rails (>= 3.7.2)
   rubocop

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,6 @@
     <meta name="theme-color" content="#118a0f">
   </head>
   <body class="<%= controller_name %> <%= action_name %>">
-    <%= content_for :render_async %>
     <%= render 'layouts/navigation' %>
 
     <header>

--- a/app/views/versions/_async_list.html.erb
+++ b/app/views/versions/_async_list.html.erb
@@ -1,9 +1,11 @@
-<div id='versions' class='versions'>
-  <% @versions.offset(10).desc(:created_at).each_with_index do |version, index| %>
-    <div class="version hidden <%= 'active' if @version.try(:id) == version.id %>">
-      <%= link_to version.message || 'No message',  send(:"#{'parser_parser_version'}_path", @versionable, version) %>
-      <p><%= localize_date_time(version.created_at) %> by <%= version.user.try(:first_name) %></p>
-      <%= environment_tags(version, @versionable) %>
-    </div>
-  <% end %>
-</div>
+<%= turbo_frame_tag :more_versions do %>
+  <div id='versions' class='versions'>
+    <% @versions.offset(10).desc(:created_at).each_with_index do |version, index| %>
+      <div class="version hidden <%= 'active' if @version.try(:id) == version.id %>">
+        <%= link_to version.message || 'No message',  send(:"#{'parser_parser_version'}_path", @versionable, version) %>
+        <p><%= localize_date_time(version.created_at) %> by <%= version.user.try(:first_name) %></p>
+        <%= environment_tags(version, @versionable) %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/versions/_list.html.erb
+++ b/app/views/versions/_list.html.erb
@@ -31,8 +31,8 @@
     </div>
   <% end %>
 
-  <%= render_async async_load_path do %>
-    <%= image_tag image_path('sj-spinner.gif', size: '40x40') %>
+  <%= turbo_frame_tag :more_versions, src: async_load_path do %>
+    <%= image_tag image_path('sj-spinner.gif', width: 40, height: 40) %>
     <strong>Loading more versions..</strong>
   <% end %>
 

--- a/config/initializers/render_async.rb
+++ b/config/initializers/render_async.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-RenderAsync.configure do |config|
-  config.turbo = true
-end


### PR DESCRIPTION
[REPLACE RENDER_ASYNC WITH HOTWIRE IN MANAGER: As Dan, I want to remove render_async, so that it's easier to maintain](https://www.pivotaltracker.com/story/show/181652360)

STORY
=====

**Acceptance Criteria**
- render_async is replaced with hotwire
- features stays the same

**Notes**
- Follows: https://www.pivotaltracker.com/story/show/181486322
- Hotwire supports rendering asynchronously parts of the pages very easily
