### PR TITLE
SJ PREVIEW DELETION MESSAGE: As Tim, I want SJ to let me know when it has marked a record for deletion, so that know what's going on.

### DIFF
--- a/app/views/previews/_preview.html.erb
+++ b/app/views/previews/_preview.html.erb
@@ -48,8 +48,8 @@
       <% end %>
 
       <% if preview.deletable %>
-        <div id="record-to-delete" class="hidden">
-          <p></strong>This record is marked for deletion.</em></p>
+        <div id="record-to-delete">
+          <p><strong>This record is marked for deletion.</strong></p>
         </div>
       <% end %>
 


### PR DESCRIPTION
[SJ PREVIEW DELETION MESSAGE: As Tim, I want SJ to let me know when it has marked a record for deletion, so that know what's going on.](https://www.pivotaltracker.com/story/show/182205031)

STORY
=====

**Acceptance Criteria**
- SJ previews inform users when a record has been marked for deletion

**Notes**
-  I think we missed testing this in one of the recent stories eg https://www.pivotaltracker.com/story/show/180640850 or https://www.pivotaltracker.com/story/show/180639571
- Cant remember where the info came through previously, but maybe it could be a status message? (let PO know if one way is easier or makes more sense)

**Tests**
- Preview this parser and you should be informed that it is planning to delete the record.
https://manager.digitalnz.org/parsers/5a1b5906297b1f4ffb7a2fb2/edit