### PR TITLE
INVESTIGATE WHY HARVESTS KEEP GETTING STUCK: As Dan, I want to know what is causing all sorts of harvest jobs to intermittently get stuck, so that we can make SJ reliable again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'rails', '~> 7.0.3'
 gem 'redis', '~> 4.0' # for action_cable in production
 gem 'rqrcode'
 gem 'server_timing'
-gem 'supplejack_common', github: 'DigitalNZ/supplejack_common', branch: 'pm/security-upgrade'
+gem 'supplejack_common', github: 'DigitalNZ/supplejack_common', tag: 'v2.10.8'
 gem 'two_factor_authentication'
 
 # Hotwire and turbo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DigitalNZ/supplejack_common
-  revision: 4640c2de5aaaa26842273f6312e2b7067273bfac
-  branch: pm/security-upgrade
+  revision: 117f6bd1d38da4e7bd50d949ac5a29851c6cc220
+  tag: v2.10.8
   specs:
     supplejack_common (0.0.2)
       actionpack
@@ -110,13 +110,13 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.605.0)
-    aws-sdk-core (3.131.2)
+    aws-partitions (1.621.0)
+    aws-sdk-core (3.135.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.57.0)
+    aws-sdk-kms (1.58.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-rekognition (1.66.0)
@@ -126,7 +126,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.5.0)
+    aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.16)
     better_errors (2.9.1)
@@ -202,7 +202,7 @@ GEM
       rainbow
       rubocop
       smart_properties
-    erubi (1.10.0)
+    erubi (1.11.0)
     factory_bot (5.2.0)
       activesupport (>= 4.2.0)
     factory_bot_rails (5.2.0)
@@ -210,12 +210,12 @@ GEM
       railties (>= 4.2.0)
     faker (2.19.0)
       i18n (>= 1.6, < 2)
-    faraday (2.3.0)
-      faraday-net_http (~> 2.0)
+    faraday (2.5.2)
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (2.0.3)
+    faraday-net_http (3.0.0)
     ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -233,7 +233,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.11.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
     irb (1.4.1)
@@ -286,10 +286,10 @@ GEM
       rake
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.16.2)
-    mongo (2.17.1)
-      bson (>= 4.8.2, < 5.0.0)
-    mongoid (7.4.0)
+    minitest (5.16.3)
+    mongo (2.18.1)
+      bson (>= 4.14.1, < 5.0.0)
+    mongoid (7.5.1)
       activemodel (>= 5.1, < 7.1, != 7.0.0)
       mongo (>= 2.10.5, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
@@ -313,7 +313,7 @@ GEM
       timeout
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.7)
+    nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oai (1.2.1)
@@ -485,7 +485,7 @@ GEM
       rails (>= 3.1.1)
       randexp
       rotp (>= 4.0.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext

--- a/app/views/abstract_jobs/_failure.html.erb
+++ b/app/views/abstract_jobs/_failure.html.erb
@@ -1,0 +1,15 @@
+<% if failure.present? %>
+  <details class="details details--warning">
+    <summary class="details__summary">
+      <h4>
+        <%= "Exception: \"#{failure.exception_class}\" with message: \"#{failure.message}\"" %>
+      </h4>
+    </summary>
+    <div class="details__content">
+      <% failure.backtrace.each do |line| %>
+        <%= line %>
+        <br>
+      <% end %>
+    </div>
+  </details>
+<% end %>

--- a/app/views/abstract_jobs/index.html.erb
+++ b/app/views/abstract_jobs/index.html.erb
@@ -22,9 +22,7 @@
         <th><%= t('harvest_jobs.enrichment') %></th>
         <th><%= t('harvest_jobs.operator') %></th>
         <th><%= t('harvest_jobs.start_time') %></th>
-        <% if %w[finished all].include?(params[:status]) %>
-          <th><%= t('harvest_jobs.duration') %></th>
-        <% end %>
+        <th><%= t('harvest_jobs.duration') %></th>
 
         <th><%= t('harvest_jobs.records_harvested') %></th>
         <th><%= t('harvest_jobs.validation_failure_errors') %></th>
@@ -65,10 +63,7 @@
         <% end %>
         <td><%= l abstract_job&.start_time, format: :start_time rescue nil %></td>
 
-        <% if %w[finished all].include?(params[:status]) %>
-          <td><%= human_readable_duration(abstract_job.duration) %></td>
-        <% end %>
-
+        <td><%= human_readable_duration(abstract_job.duration) %></td>
         <td><%= abstract_job.records_count %></td>
 
         <% if ((abstract_job.invalid_records_count.present? && abstract_job.invalid_records_count > 0) || (abstract_job.failed_records_count.present? && abstract_job.failed_records_count > 0)) %>

--- a/app/views/enrichment_jobs/_enrichment_job.html.erb
+++ b/app/views/enrichment_jobs/_enrichment_job.html.erb
@@ -171,5 +171,8 @@
       <% end %>
     </table>
 
+    <%= render partial: 'abstract_jobs/failure', locals: { failure: @enrichment_job.enrichment_failure } %>
+    <%= render partial: 'abstract_jobs/failure', locals: { failure: @enrichment_job.harvest_failure } %>
+
   <% end %>
 <% end %>

--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -113,14 +113,16 @@
         </td>
       </tr>
 
-      <% if @harvest_job.failed? || @harvest_job.finished? %>
+      <% if @harvest_job.duration.present? %>
         <tr>
           <td><%= t('harvest_jobs.duration') %></td>
           <td>
-              <strong><%= human_readable_duration(@harvest_job.duration) %></strong>
+            <strong><%= human_readable_duration(@harvest_job.duration) %></strong>
           </td>
         </tr>
+      <% end %>
 
+      <% if @harvest_job.failed? || @harvest_job.finished? %>
         <tr>
           <td><%= t('harvest_jobs.records_per_second') %></td>
           <td>

--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -181,22 +181,7 @@
       <% end %>
     </table>
 
-    <% if @harvest_job.harvest_failure.present? %>
-      <h5><%= t('harvest_jobs.harvest_failure') %> </h5>
-
-      <div id="harvest-job-errors-backtrace">
-        <div id="accordion-backtrace" class="accordion">
-          <h3 class="error">
-            <span><%= @harvest_job.harvest_failure.message %></span>
-          </h3>
-          <div>
-            <small>
-              <%= text_area_tag '', JSON.pretty_generate(JSON.parse(@harvest_job.harvest_failure.backtrace.to_s)), class: 'code-editor-multiple readonly' %>
-            </small>
-          </div>
-        </div>
-      </div>
-    <% end %>
+    <%= render partial: 'abstract_jobs/failure', locals: { failure: @harvest_job.harvest_failure } %>
 
     <h5><%= t('harvest_jobs.invalid_records') %> <span class="errors-count">(<%= @harvest_job.invalid_records_count.to_i %>)</span></h5>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,6 +200,7 @@ en:
     type: "Job Type"
     harvestjob: "Harvest"
     enrichmentjob: "Enrichment"
+    failure_title: "Job failure"
 
   harvest_jobs:
     label: "Harvest Jobs"
@@ -230,7 +231,6 @@ en:
     scheduled: "Scheduled"
     already_active_html: "There is already an active Job running for the <strong>%{parser}</strong> in the <strong>%{environment}</strong> environment"
     incremental: "Incremental Harvest?"
-    harvest_failure: "Harvest failure"
     records_posted: "Records posted to API"
     mode: "Mode"
     enrichment: "Enrichment"

--- a/spec/factories/enrichment_job.rb
+++ b/spec/factories/enrichment_job.rb
@@ -23,6 +23,9 @@ FactoryBot.define do
     record_id { 1 }
     last_posted_record_id { 'last posted record id' }
 
+    association :enrichment_failure, factory: :job_failure
+    association :harvest_failure, factory: :job_failure
+
     trait :finished do
       status { 'finished' }
     end

--- a/spec/factories/harvest_job.rb
+++ b/spec/factories/harvest_job.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     status { 'ready' }
     environment { 'staging' }
 
-    harvest_failure { OpenStruct.new(backtrace: '{}') }
+    association :harvest_failure, factory: :job_failure
     invalid_records { [] }
     failed_records { [] }
 

--- a/spec/factories/job_failure.rb
+++ b/spec/factories/job_failure.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :job_failure, class: 'OpenStruct' do
+    message { 'Error message' }
+    exception_class { 'StandardError' }
+    backtrace { ['file_1[1]', 'file_2[10]'] }
+  end
+end


### PR DESCRIPTION
[INVESTIGATE WHY HARVESTS KEEP GETTING STUCK: As Dan, I want to know what is causing all sorts of harvest jobs to intermittently get stuck, so that we can make SJ reliable again](https://www.pivotaltracker.com/story/show/182936549)

STORY
=====

**Acceptance Criteria**
- Investigate/understand cause of intermittent stuck harvests
- Draft stories as needed

**Notes**
- For a while now we've been seeing issues with harvest jobs getting stuck more than they used to. I havnt been able to find much in the way of useful clues, but here are my observations:
 - every few days there will be a couple of stuck jobs. 
 - quite often a few at once. 
 - across prod and staging
 - They are mostly enrichments
 - I cant see a pattern to the type of harvest/enrichment (ie its effecting a variety of parsers)
- The end-to-end parser is a useful example as it runs twice a day, and seems to get stuck around 20% of the time. Which ends up triggering my alerts :( until I manually stop the job.
Looking at the STOPPED jobs for the end-to-end harvest ([staging](https://manager.digitalnz.org/staging/jobs?parser_id=5c6c8d552c2bae7f8b0133e3&status=stopped) and [prod](https://manager.digitalnz.org/production/jobs?parser_id=5c6c8d552c2bae7f8b0133e3&status=stopped)) shows: 
 - its randomly across all 3 of its enrichments (some are very basic)
 - scattered every few days (when you combine staging and prod)
 - started earlier in the year (Feb / Mar)


**Tests**
- ?

**Impacts**
- Annoying and noisily triggering end-to-end alerts