### PR TITLE
SUPPLEJACK UX TWEAKS: As Tim H, I want a few small handy visual tweaks to SJ, so that my day-to-day harvesting process is easier

### DIFF
--- a/app/assets/stylesheets/blocks/_harvest_jobs.scss
+++ b/app/assets/stylesheets/blocks/_harvest_jobs.scss
@@ -17,26 +17,6 @@
   }
 }
 
-.parser-title {
-  display: none;
-}
-
-.enrichment-job-full,
-.harvest-job-full {
-  .parser-title {
-    display: inline;
-  }
-  table {
-    clear: both;
-  }
-
-  #harvest-job {
-    .button {
-      margin-top: 14px;
-    }
-  }
-}
-
 #harvest-modal {
   .errors-count {
     display: none;

--- a/app/javascript/src/parsers.js
+++ b/app/javascript/src/parsers.js
@@ -3,17 +3,13 @@
 // All this logic will automatically be available in application.js.
 // You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
 
-var stored_sources;
-
-stored_sources = null;
+var stored_sources = null;
 
 document.addEventListener("turbo:load", function () {
   $("form[action^='/parsers/'] input[name='parser[message]'").on(
     "submit",
     function (e) {
-      var parser_message;
-      parser_message = $('input[name="parser[message]"').val();
-      if (!parser_message) {
+      if (!$('input[name="parser[message]"').val()) {
         alert("Message is required");
         return e.preventDefault();
       }
@@ -67,7 +63,7 @@ document.addEventListener("turbo:load", function () {
       {
         data: "name",
         render: function (data, type, row, meta) {
-          return '<a href="/parsers/' + row.id + '/edit">' + data + "</a>";
+          return `<a href="/parsers/${row.id}/edit">${data}</a>`;
         },
       },
       { data: "strategy" },
@@ -75,26 +71,14 @@ document.addEventListener("turbo:load", function () {
         data: "partner_name",
         render: function (data, type, row, meta) {
           if (!row.can_update) return row.partner_name;
-          return (
-            '<a href="/partners/' +
-            row.partner.id +
-            '/edit">' +
-            row.partner.name +
-            "</a>"
-          );
+          return `<a href="/partners/${row.partner.id}/edit">${row.partner.name}</a>`;
         },
       },
       {
         data: "source_name",
         render: function (data, type, row, meta) {
           if (!row.can_update) return row.source.name;
-          return (
-            '<a href="/sources/' +
-            row.source.id +
-            '/edit">' +
-            row.source.name +
-            "</a>"
-          );
+          return `<a href="/sources/${row.source.id}/edit">${row.source.name}</a>`;
         },
       },
       { data: "updated_at" },

--- a/app/views/abstract_jobs/index.html.erb
+++ b/app/views/abstract_jobs/index.html.erb
@@ -1,4 +1,9 @@
-<h1><%= params[:status].capitalize %> Jobs - <%= params[:environment].capitalize %></h1>
+<% title = "#{params[:status].capitalize} Jobs - #{params[:environment].capitalize}" %>
+<%= content_for :title do %>
+  <%= title %>
+<% end %>
+
+<h1><%= title %></h1>
 
 <% %w[all active finished failed stopped].each do |status| %>
   <%= link_to(

--- a/app/views/admin/activities/index.html.erb
+++ b/app/views/admin/activities/index.html.erb
@@ -1,3 +1,11 @@
+<%= content_for :title do %>
+  API Activities
+<% end %>
+
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <h1>API Activities</h1>
 
 <%= link_to('Download CSV', environment_admin_activities_path(format: :csv), class: 'button primary new-right') %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,10 +1,17 @@
-<h2><%= @user['id'] %></h2>
+<%= content_for :title do %>
+  Edit user
+<% end %>
+
+<h1>Edit user (<%= @user['id'] %>)</h1>
 
 <%= form_for :user,
              url: environment_admin_user_path(environment: params[:environment],
              id: @user['id']),
              method: :patch,
              html: { id: "edit-user-form-#{@user['id']}" } do |f| %>
-  <input type='text' name='max_requests' autocomplete="off" value="<%= @user['max_requests'] %>">
+  <label>
+    Max requests
+    <input type='text' name='max_requests' autofocus autocomplete="off" value="<%= @user['max_requests'] %>">
+  </label>
   <%= f.submit class: 'button' %>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,12 @@
-<h2>API Users</h2>
+<%= content_for :title do %>
+  API Users
+<% end %>
+
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
+<h1>API Users</h1>
 
 <%= link_to('Download CSV', environment_admin_users_path(format: :csv), class: 'button primary new-right') %>
 

--- a/app/views/collection_records/index.html.erb
+++ b/app/views/collection_records/index.html.erb
@@ -1,7 +1,12 @@
+<% title = "#{t('records.label')} - #{params[:environment].capitalize}" %>
+<%= content_for :title do %>
+  <%= title %>
+<% end %>
+
 <div class="medium-8 cell centered">
 
   <div class="grid-x">
-    <h1 class="float-left"><%= t('records.label') %> - <%= params[:environment].capitalize %></h1>
+    <h1 class="float-left"><%= title %></h1>
   </div>
 
   <div class="grid-x">

--- a/app/views/collection_statistics/index.html.erb
+++ b/app/views/collection_statistics/index.html.erb
@@ -1,4 +1,13 @@
-<h1 class="left">Link Checking Report - <%= params[:environment].capitalize %></h1>
+<% title = "Link Checking Report - #{params[:environment].capitalize}" %>
+<%= content_for :title do %>
+  <%= title %>
+<% end %>
+
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
+<h1><%= title %></h1>
 
 <table id="stats">
   <thead>

--- a/app/views/collection_statistics/show.html.erb
+++ b/app/views/collection_statistics/show.html.erb
@@ -1,8 +1,12 @@
-<h2 class="collection-stats-heading">
+<%= content_for :title do %>
+  Collection Statistics for: <%= @day.to_date.to_formatted_s(:long) %>
+<% end %>
+
+<h1 class="collection-stats-heading">
   <%= link_to_previous_day @day, params[:environment], class: 'cycle-prev-day-button arrow arrow-left' %>
   <span><%= params[:environment].try(:capitalize) %> Collection Statistics for: <%= @day.to_date.to_formatted_s(:long) %></span>
   <%= link_to_next_day @day, params[:environment], class: 'cycle-next-day-button arrow arrow-right' %>
-</h2>
+</h1>
 
 <% unless @collection_statistics.any? %>
   <div class="medium-12 cell">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :title do %>
+  Sign In
+<% end %>
+
 <div class="columns centered">
   <div class="devise-block">
     <div class="four columns centered">

--- a/app/views/devise/two_factor_authentication/show.html.erb
+++ b/app/views/devise/two_factor_authentication/show.html.erb
@@ -1,11 +1,17 @@
-<div>
+<%= content_for :title do %>
+  MFA Login
+<% end %>
 
-  <h2>Please enter the code from your authenticator app:</h2>
+<h1>Multi-factor Authentication</h1>
 
-  <%= form_tag([resource_name, :two_factor_authentication], method: :put, data: { turbo: false }) do %>
+<p>Please enter the code from your authenticator app:</p>
+
+<%= form_tag([resource_name, :two_factor_authentication], method: :put, data: { turbo: false }) do %>
+  <label>
+    MFA Code
     <%= text_field_tag :code, '', autocomplete: :off, autofocus: true %>
-    <%= submit_tag 'Log in', class: 'button btn-primary' %>
-  <% end %>
+  </label>
+  <%= submit_tag 'Log in', class: 'button btn-primary' %>
+<% end %>
 
-  <%= link_to 'Sign out', destroy_user_session_path, method: :delete %>
-</div>
+<%= link_to 'Sign out', destroy_user_session_path, method: :delete %>

--- a/app/views/devise/two_factor_authentication/show.html.erb
+++ b/app/views/devise/two_factor_authentication/show.html.erb
@@ -3,7 +3,7 @@
   <h2>Please enter the code from your authenticator app:</h2>
 
   <%= form_tag([resource_name, :two_factor_authentication], method: :put, data: { turbo: false }) do %>
-    <%= text_field_tag :code, '', autocomplete: :off %>
+    <%= text_field_tag :code, '', autocomplete: :off, autofocus: true %>
     <%= submit_tag 'Log in', class: 'button btn-primary' %>
   <% end %>
 

--- a/app/views/enrichment_jobs/_enrichment_job.html.erb
+++ b/app/views/enrichment_jobs/_enrichment_job.html.erb
@@ -11,11 +11,11 @@
   ) do %>
 
     <h2 class="left">
-      <%= t('enrichment_jobs.progress') %>
+      <%= t('enrichment_jobs.progress') %>:
       <% if can? :update, @enrichment_job.parser %>
-        <span class="parser-title">: <%= link_to @enrichment_job.parser.try(:name), edit_parser_path(@enrichment_job.parser), target: :_top %></span>
+        <%= link_to @enrichment_job.parser.try(:name), edit_parser_path(@enrichment_job.parser), target: :_top %>
       <% else %>
-        <span class="parser-title">: <%= @enrichment_job.parser.try(:name) %></span>
+        <%= @enrichment_job.parser.try&.name %>
       <% end %>
     </h2>
 

--- a/app/views/enrichment_jobs/_enrichment_job.html.erb
+++ b/app/views/enrichment_jobs/_enrichment_job.html.erb
@@ -10,7 +10,7 @@
     }
   ) do %>
 
-    <h2 class="left">
+    <h2>
       <%= t('enrichment_jobs.progress') %>:
       <% if can? :update, @enrichment_job.parser %>
         <%= link_to @enrichment_job.parser.try(:name), edit_parser_path(@enrichment_job.parser), target: :_top %>

--- a/app/views/enrichment_jobs/show.html.erb
+++ b/app/views/enrichment_jobs/show.html.erb
@@ -1,1 +1,5 @@
+<%= content_for :title do %>
+  Enrichment progress
+<% end %>
+
 <%= render partial: 'enrichment_poll' %>

--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -10,7 +10,7 @@
     }
   ) do %>
 
-    <h2 class="left">
+    <h2>
       <%= t('harvest_jobs.progress') %>:
       <% if @harvest_job.parser.present? %>
         <% if can? :update, @harvest_job.parser %>

--- a/app/views/harvest_jobs/_harvest_job.html.erb
+++ b/app/views/harvest_jobs/_harvest_job.html.erb
@@ -11,12 +11,12 @@
   ) do %>
 
     <h2 class="left">
-      <%= t('harvest_jobs.progress') %>
+      <%= t('harvest_jobs.progress') %>:
       <% if @harvest_job.parser.present? %>
         <% if can? :update, @harvest_job.parser %>
-          <span class="parser-title">: <%= link_to @harvest_job.parser&.name, edit_parser_path(@harvest_job.parser), target: '_top' %></span>
+          <%= link_to @harvest_job.parser&.name, edit_parser_path(@harvest_job.parser), target: '_top' %>
         <% else %>
-          <span class="parser-title">: <%= @harvest_job.parser.try(:name) %></span>
+          <%= @harvest_job.parser&.name %>
         <% end %>
       <% end %>
     </h2>

--- a/app/views/harvest_jobs/show.html.erb
+++ b/app/views/harvest_jobs/show.html.erb
@@ -1,1 +1,5 @@
+<%= content_for :title do %>
+  Harvest progress
+<% end %>
+
 <%= render partial: 'harvest_poll' %>

--- a/app/views/harvest_schedules/edit.html.erb
+++ b/app/views/harvest_schedules/edit.html.erb
@@ -1,4 +1,9 @@
-<h2><%= t('harvest_schedules.edit_env_schedule', env: params[:environment].capitalize) %></h2>
+<% title = t('harvest_schedules.edit_env_schedule', env: params[:environment].capitalize) %>
+<%= content_for :title do %>
+  <%= title %>
+<% end %>
+
+<h1><%= title %></h1>
 
 <div id="harvest-schedule-form">
   <%= render 'form' %>

--- a/app/views/harvest_schedules/index.html.erb
+++ b/app/views/harvest_schedules/index.html.erb
@@ -1,4 +1,9 @@
-<h2>Job Schedules - <%= params[:environment].capitalize %></h2>
+<% title = "Job Schedules #{params[:environment].capitalize}" %>
+<%= content_for :title do %>
+  <%= title %>
+<% end %>
+
+<h1><%= title %></h1>
 
 <%= link_to 'New Schedule', new_environment_harvest_schedule_path(params[:environment]), class: "button float-right #{ can_show_button(:create, HarvestSchedule) }" %>
 

--- a/app/views/harvest_schedules/new.html.erb
+++ b/app/views/harvest_schedules/new.html.erb
@@ -1,6 +1,11 @@
+<% title = t('harvest_schedules.new_env_schedule', env: params[:environment].capitalize) %>
+<%= content_for :title do %>
+  <%= title %>
+<% end %>
+
 <div class="grid-x">
   <div class="medium-7 cell">
-    <h2><%= t('harvest_schedules.new_env_schedule', env: params[:environment].capitalize) %></h2>
+    <h1><%= title %></h1>
 
     <div id="harvest-schedule-form">
       <%= render 'form' %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :title do %>
+  Dashboard
+<% end %>
+
 <div class="medium-12 cell centered">
 
   <div class="grid-x">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,10 @@
 <html class='no-js'>
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title><%= content_for?(:title) ? yield(:title) : 'Harvester Manager' %></title>
+    <title>
+      <%= content_for?(:title) ? "#{yield(:title)} | " : '' %>
+      Harvester Manager
+    </title>
     <meta name="description" content="<%= content_for?(:description) ? yield(:description) : 'Harvester Manager' %>">
     <%= csp_meta_tag %>
     <%= csrf_meta_tags %>

--- a/app/views/link_check_rules/edit.html.erb
+++ b/app/views/link_check_rules/edit.html.erb
@@ -1,6 +1,10 @@
+<%= content_for :title do %>
+  <%= @link_check_rule.source.source_id %>
+<% end %>
+
 <div class="grid-x">
   <div class="medium-8 cell">
-    <h2 id="link-check-rule-title" class="left"><%= @link_check_rule.source.source_id %></h2>
+    <h1 id="link-check-rule-title"><%= @link_check_rule.source.source_id %></h1>
     <%= render 'form', url: environment_link_check_rule_path(id: @link_check_rule.id, environment: params[:environment]) %>
   </div>
 </div>

--- a/app/views/link_check_rules/index.html.erb
+++ b/app/views/link_check_rules/index.html.erb
@@ -1,4 +1,13 @@
-<h1 class="left">Link Check Rules - <%= params[:environment].capitalize %></h1>
+<% title = "Link Check Rules - #{params[:environment].capitalize}" %>
+<%= content_for :title do %>
+  <%= title %>
+<% end %>
+
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
+<h1><%= title %></h1>
 <%= link_to 'New link check rule', new_environment_link_check_rule_path(environment: params[:environment]), class: "button new-right #{can_show_button(:create, LinkCheckRule)}" %>
 
 <table id="link_check_rules">

--- a/app/views/link_check_rules/new.html.erb
+++ b/app/views/link_check_rules/new.html.erb
@@ -1,6 +1,10 @@
+<%= content_for :title do %>
+  <%= t('link_checker.create_a') %>
+<% end %>
+
 <div class="grid-x">
   <div class="medium-8 cell">
-    <h2 id="link-check-rule-title" class="left"><%= t('link_checker.create_a') %></h2>
+    <h1 id="link-check-rule-title"><%= t('link_checker.create_a') %></h1>
     <%= render 'form', url: environment_link_check_rules_path(environment: params[:environment]) %>
   </div>
 </div>

--- a/app/views/lint_parser/show.html.erb
+++ b/app/views/lint_parser/show.html.erb
@@ -1,16 +1,20 @@
+<%= content_for :title do %>
+  Lint result
+<% end %>
+
 <div class='grid-x grid-margin-x'>
   <div class='medium-9 cell'>
     <h1><%= "Lint result for #{@parser.name}" %></h1>
 
-      <div class='callout warning text-center' data-alert=''>
-        <%= @linter.warnings_count %>
-      </div>
+    <div class='callout warning text-center' data-alert=''>
+      <%= @linter.warnings_count %>
+    </div>
 
-      <% @linter.warnings.each do |warning| %>
-        <% unless warning.blank? %>
-          <%= warning %>
-          <hr>
-        <% end %>
+    <% @linter.warnings.each do |warning| %>
+      <% unless warning.blank? %>
+        <%= warning %>
+        <hr>
       <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/parser_templates/edit.html.erb
+++ b/app/views/parser_templates/edit.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :title do %>
+  <%= @parser_template.name %>
+<% end %>
+
 <div class="grid-x">
   <div class="medium-5 cell">
 

--- a/app/views/parser_templates/index.html.erb
+++ b/app/views/parser_templates/index.html.erb
@@ -1,3 +1,11 @@
+<%= content_for :title do %>
+  <%= t('parser_templates.label') %>
+<% end %>
+
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <h1><%= t('parser_templates.label') %></h1>
 
 <%= link_to t('parser_templates.create'), new_parser_template_path, class: "button new-right #{can_show_button(:create, Parser)}" %>

--- a/app/views/parser_templates/new.html.erb
+++ b/app/views/parser_templates/new.html.erb
@@ -1,4 +1,8 @@
-<h2><%= t('parser_templates.create_a') %></h2>
+<%= content_for :title do %>
+  <%= t('parser_templates.create_a') %>
+<% end %>
+
+<h1><%= t('parser_templates.create_a') %></h1>
 
 <h5 class="subheader">
   <%= t('parser_templates.helptext') %>

--- a/app/views/parser_templates/show.html.erb
+++ b/app/views/parser_templates/show.html.erb
@@ -1,8 +1,8 @@
-<div class="grid-x">
-  <div class="medium-9 cell">
-    <h1 id="parser-template-title" class="float-left"><%= @parser_template.name %></h1>
-  </div>
-</div>
+<%= content_for :title do %>
+  <%= @parser_template.name %>
+<% end %>
+
+<h1><%= @parser_template.name %></h1>
 
 <%= custom_form_with model: @parser_template do |f| %>
   <%= f.text_area :content, class: 'code-editor read-only' %>

--- a/app/views/parser_versions/show.html.erb
+++ b/app/views/parser_versions/show.html.erb
@@ -1,1 +1,5 @@
+<%= content_for :title do %>
+  <%= @parser.name %>
+<% end %>
+
 <%= render @parser %>

--- a/app/views/parsers/_parser.html.erb
+++ b/app/views/parsers/_parser.html.erb
@@ -1,17 +1,16 @@
 <div class='grid-x grid-margin-x'>
-  <div class='medium-9 cell'>
+  <div class='cell'>
     <% if can? :update, @parser %>
-      <h1 id='resource-title' data-toggler='.hide' class='float-left'>
+      <h1>
         <%= @parser.name %>
         <span class="parser-tag <%= 'alert' if @parser.data_type == 'concept' %> round label"><%= @parser.data_type %></span>
       </h1>
     <% else %>
-      <h1 id='parser-title' class='float-left'><%= @parser.name %></h1>
+      <h1><%= @parser.name %></h1>
     <% end %>
   </div>
-  <div class='medium-3 cell'>
-  </div>
 </div>
+
 <div class='grid-x grid-margin-x'>
   <div class='medium-9 cell'>
     <% if @version %>

--- a/app/views/parsers/edit.html.erb
+++ b/app/views/parsers/edit.html.erb
@@ -1,1 +1,5 @@
+<%= content_for :title do %>
+  <%= @parser.name %>
+<% end %>
+
 <%= render @parser %>

--- a/app/views/parsers/edit_meta.html.erb
+++ b/app/views/parsers/edit_meta.html.erb
@@ -1,3 +1,9 @@
+<%= content_for :title do %>
+  Edit meta
+<% end %>
+
+<h1>Edit metadata of "<%= @parser.name %>"</h1>
+
 <div class='medium-12 cell'>
   <%= custom_form_with model: @parser do |f| %>
     <%= f.label :name %>

--- a/app/views/parsers/index.html.erb
+++ b/app/views/parsers/index.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <div id="parsers-index">
   <h1><%= t('parsers.label') %></h1>
 

--- a/app/views/parsers/index.html.erb
+++ b/app/views/parsers/index.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :title do %>
+  <%= t('parsers.label') %>
+<% end %>
+
 <%= content_for :head do %>
   <meta name="turbo-cache-control" content="no-cache">
 <% end %>

--- a/app/views/parsers/new.html.erb
+++ b/app/views/parsers/new.html.erb
@@ -1,5 +1,9 @@
+<%= content_for :title do %>
+  <%= t('parsers.create_a') %>
+<% end %>
+
 <div class="medium-12 cell">
-  <h2><%= t('parsers.create_a') %></h2>
+  <h1><%= t('parsers.create_a') %></h1>
 
   <h5 class="subheader">
     <%= t('parsers.new.helptext') %>

--- a/app/views/parsers/show.html.erb
+++ b/app/views/parsers/show.html.erb
@@ -1,6 +1,10 @@
+<%= content_for :title do %>
+  <%= @parser.name %>
+<% end %>
+
 <div class="grid-x">
   <div class="medium-9 cell">
-    <h1 id="parser-title" class="left"><%= @parser.name %></h1>
+    <h1><%= @parser.name %></h1>
   </div>
 
   <div class="medium-3 cell">

--- a/app/views/partners/edit.html.erb
+++ b/app/views/partners/edit.html.erb
@@ -1,5 +1,9 @@
+<%= content_for :title do %>
+  <%= t('partners.edit') %>
+<% end %>
+
 <div class="seven columns centered">
-  <h2><%= t('partners.edit') %></h2>
+  <h1><%= t('partners.edit') %></h1>
 
   <%= render 'form' %>
 </div>

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -1,3 +1,11 @@
+<%= content_for :title do %>
+  <%= t('partners.label') %>
+<% end %>
+
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <h1><%= t('partners.label') %></h1>
 <%= link_to t('partners.create'), new_partner_path, class: "button new-right #{can_show_button(:create, Partner)}" %>
 

--- a/app/views/partners/new.html.erb
+++ b/app/views/partners/new.html.erb
@@ -1,5 +1,9 @@
+<%= content_for :title do %>
+  <%= t('partners.create_a') %>
+<% end %>
+
 <div class="seven columns centered">
-  <h2><%= t('partners.create_a') %></h2>
+  <h1><%= t('partners.create_a') %></h1>
 
   <h5 class="subheader">
     <%= t('partners.new.helptext') %>

--- a/app/views/snippet_versions/show.html.erb
+++ b/app/views/snippet_versions/show.html.erb
@@ -1,1 +1,5 @@
+<%= content_for :title do %>
+  <%= @snippet.name %>
+<% end %>
+
 <%= render @snippet %>

--- a/app/views/snippets/edit.html.erb
+++ b/app/views/snippets/edit.html.erb
@@ -1,1 +1,5 @@
+<%= content_for :title do %>
+  <%= @snippet.name %>
+<% end %>
+
 <%= render @snippet %>

--- a/app/views/snippets/index.html.erb
+++ b/app/views/snippets/index.html.erb
@@ -1,3 +1,11 @@
+<%= content_for :title do %>
+  <%= t('snippets.label') %>
+<% end %>
+
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <h1><%= t('snippets.label') %></h1>
 <%= link_to t('snippets.create'), new_snippet_path, class: "button new-right #{can_show_button(:create, Parser)}" %>
 

--- a/app/views/snippets/new.html.erb
+++ b/app/views/snippets/new.html.erb
@@ -1,4 +1,8 @@
-<h2><%= t('snippets.create_a') %></h2>
+<%= content_for :title do %>
+  <%= t('snippets.create_a') %>
+<% end %>
+
+<h1><%= t('snippets.create_a') %></h1>
 
 <%= custom_form_with model: @snippet do |f| %>
   <%= f.label :name %>

--- a/app/views/snippets/show.html.erb
+++ b/app/views/snippets/show.html.erb
@@ -1,1 +1,5 @@
+<%= content_for :title do %>
+  <%= @snippet.name %>
+<% end %>
+
 <%= render @snippet %>

--- a/app/views/sources/edit.html.erb
+++ b/app/views/sources/edit.html.erb
@@ -1,19 +1,18 @@
-<br>
-<div id="alert"></div>
+<%= content_for :title do %>
+  <%= t('sources.edit') %>
+<% end %>
 
-<div class="medium-7 cell">
-  <h2><%= t('sources.edit') %></h2>
+<h1><%= t('sources.edit') %></h1>
 
-  <%= render 'form' %>
+<%= render 'form' %>
 
-  <% if can? :manage, @source %>
-    <h2><%= t('sources.manage') %></h2>
-    <a href="#" data-open="reindex-modal" class="button float-right"><%= t('sources.reindex') %></a>
-  <% end %>
-</div>
+<% if can? :manage, @source %>
+  <h2><%= t('sources.manage') %></h2>
+  <a href="#" data-open="reindex-modal" class="button float-right"><%= t('sources.reindex') %></a>
+<% end %>
 
 <div id="reindex-modal" class="reveal medium" data-reveal>
-  <h2><%= t('sources.reindex') %></h2>
+  <h1><%= t('sources.reindex') %></h1>
   <div class="grid-x">
     <div class="medium-12 cell">
       <label class=""><%= t('forms.labels.sources.environment') %></label>

--- a/app/views/sources/index.html.erb
+++ b/app/views/sources/index.html.erb
@@ -1,3 +1,11 @@
+<%= content_for :title do %>
+  <%= t('sources.label') %>
+<% end %>
+
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <h1><%= t('sources.label') %></h1>
 <%= link_to t('sources.create'), new_source_path, class: "button new-right #{can_show_button(:create, Source)}" %>
 

--- a/app/views/sources/new.html.erb
+++ b/app/views/sources/new.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :title do %>
+  <%= t('sources.create_a') %>
+<% end %>
+
 <div class="eight columns centered">
   <h1><%= t('sources.create_a') %></h1>
 

--- a/app/views/sources/reindex.js
+++ b/app/views/sources/reindex.js
@@ -1,4 +1,0 @@
-$("#reindex-modal").trigger("close");
-$("#alert").html(
-  '<div class="alert-box success success-box">Reindexing has begun...</div>'
-);

--- a/app/views/suppress_collections/index.html.erb
+++ b/app/views/suppress_collections/index.html.erb
@@ -1,4 +1,9 @@
-<h1><%= t('link_checker.suppress_collections.label') %> - <%= params[:environment].capitalize %></h1>
+<% title = "#{t('link_checker.suppress_collections.label')} - #{params[:environment].capitalize}" %>
+<%= content_for :title do %>
+  <%= title %>
+<% end %>
+
+<h1><%= title %></h1>
 
 <h5 class="subheader">
   <%= t('link_checker.suppress_collections.helptext') %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,11 +1,11 @@
+<% title = @user == current_user ? 'Edit Profile' : 'Edit User' %>
+
+<%= content_for :title do %>
+  <%= title %>
+<% end %>
+
 <div class="eight columns centered">
-  <h1>
-    <% if @user == current_user %>
-        Edit Profile
-    <% else %>
-        Edit User
-    <% end %>
-  </h1>
+  <h1><%= title %></h1>
 
   <%= render 'form' %>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,11 @@
+<%= content_for :title do %>
+  Users
+<% end %>
+
+<%= content_for :head do %>
+  <meta name="turbo-cache-control" content="no-cache">
+<% end %>
+
 <h1>Users</h1>
 
 <% if can? :create, User %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,7 @@
+<%= content_for :title do %>
+  New user
+<% end %>
+
 <div class="eight columns centered">
   <h1>New user</h1>
 


### PR DESCRIPTION
[SUPPLEJACK UX TWEAKS: As Tim H, I want a few small handy visual tweaks to SJ, so that my day-to-day harvesting process is easier](https://www.pivotaltracker.com/story/show/183135300)

STORY
=====

**Acceptance Criteria**
- H1 title is used as the browser tab name for all SJ pages 
- Job details pages show the name of the parser - as a link to that  parser (`/parsers/xx/versions/xx`)
- [Parser page](https://manager.digitalnz.org/parsers) filter panel doesnt duplicate (shown in screenshot) when leaving (click a parser) and returning (via back button)
- 2FA form element takes default curser focus


**Risks**
- ?

**Notes**
- It feels like that second AC is something we used to have but has fallen off recently. So check if the code is there and reimplement, otherwise talk to Dan about where to put the name.

**Tests**
- How can we test for success?

**Impacts**
- These are hopefully small fixes but will greatly help the daily harvesting experience.
